### PR TITLE
try and use importlib where possible

### DIFF
--- a/src/flowkit/_resources/__init__.py
+++ b/src/flowkit/_resources/__init__.py
@@ -1,23 +1,20 @@
 """
 Contains non-code resources used in FlowKit
 """
-from pkg_resources import resource_filename
+
+from importlib import resources
 from lxml import etree
-import os
-import pathlib
 
-resource_path = resource_filename('flowkit', '_resources')
-# force POSIX-style path, even on Windows
-resource_path = pathlib.Path(resource_path).as_posix()
+try:
+    resource_dir = resources.files("flowkit")
+    xsd_file = resource_dir / "_resources" / "Gating-ML.v2.0.xsd"
+except AttributeError:
+    from pkg_resources import resource_filename
+    from pathlib import Path
 
-# We used to edit the import paths for Transformations & DataTypes,
-# but it still caused an XMLSchemaParseError when FlowKit was
-# installed in a location where the path contained "special"
-# characters (i.e. accented letters). Instead, we now change
-# directories temporarily to the XSD location, read in the files,
-# and then change back to the original CWD.
-orig_dir = os.getcwd()
-os.chdir(resource_path)
-gml_tree = etree.parse('Gating-ML.v2.0.xsd')
+    resource_dir = resource_filename("flowkit", "_resources")
+    xsd_file = Path(resource_dir) / "Gating-ML.v2.0.xsd"
+
+with xsd_file.open("rb") as file:
+    gml_tree = etree.parse(file)
 gml_schema = etree.XMLSchema(gml_tree)
-os.chdir(orig_dir)


### PR DESCRIPTION
Hey Scott,

I was just installing your new version in my new environment in Python 3.12.
I noticed that pkg_resources was missing from the installation causing a ModuleNotFoundError.
This could be fixed by running `pip install setuptools` but still gives a deprecation warning.
I tried to changing to importlib as the docs suggest, but the files API is missing from older versions of Python (3.8 for sure haven't checked the others).
This could be a workaround for all currently tested version and at some point you can drop the try/except clause.
I also tried what the comment suggested with the special characters, and it didn't raise any errors for me so I went ahead and removed that section.
Let me know what you think :)

Best,
Tristan