### PR TITLE
Small test refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff:
 .idea
+.vscode
 scratch/
 scratch_data/
 *.png

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,24 +3,24 @@ FlowKit Test Suites
 """
 import unittest
 
-from .sample_tests import SampleTestCase
-from .sample_export_tests import SampleExportTestCase
-from .gatingml_tests import GatingMLTestCase
-from .gating_strategy_prog_gate_tests import GatingTestCase
-from .export_gml_tests import ExportGMLTestCase
-from .gating_strategy_tests import GatingStrategyTestCase
-from .gating_strategy_reused_gates_tests import GatingStrategyReusedGatesTestCase
-from .gating_strategy_remove_gates_tests import GatingStrategyRemoveGatesTestCase
-from .gating_strategy_custom_gates_tests import GatingStrategyCustomGatesTestCase
-from .session_tests import SessionTestCase
-from .session_export_tests import SessionExportTestCase
-from .workspace_tests import WorkspaceTestCase
-from .gating_results_tests import GatingResultsTestCase
-from .matrix_tests import MatrixTestCase
-from .transform_tests import TransformsTestCase
-from .gate_tests import GateTestCase
-from .string_repr_tests import StringReprTestCase
-from .plot_tests import PlotTestCase
+from tests.sample_tests import SampleTestCase
+from tests.sample_export_tests import SampleExportTestCase
+from tests.gatingml_tests import GatingMLTestCase
+from tests.gating_strategy_prog_gate_tests import GatingTestCase
+from tests.export_gml_tests import ExportGMLTestCase
+from tests.gating_strategy_tests import GatingStrategyTestCase
+from tests.gating_strategy_reused_gates_tests import GatingStrategyReusedGatesTestCase
+from tests.gating_strategy_remove_gates_tests import GatingStrategyRemoveGatesTestCase
+from tests.gating_strategy_custom_gates_tests import GatingStrategyCustomGatesTestCase
+from tests.session_tests import SessionTestCase
+from tests.session_export_tests import SessionExportTestCase
+from tests.workspace_tests import WorkspaceTestCase
+from tests.gating_results_tests import GatingResultsTestCase
+from tests.matrix_tests import MatrixTestCase
+from tests.transform_tests import TransformsTestCase
+from tests.gate_tests import GateTestCase
+from tests.string_repr_tests import StringReprTestCase
+from tests.plot_tests import PlotTestCase
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/export_gml_tests.py
+++ b/tests/export_gml_tests.py
@@ -9,9 +9,7 @@ import numpy as np
 import pandas as pd
 
 from flowkit import Sample, Session
-
-data1_fcs_path = 'data/gate_ref/data1.fcs'
-data1_sample = Sample(data1_fcs_path)
+from tests.test_config import data1_sample
 
 
 class ExportGMLTestCase(unittest.TestCase):

--- a/tests/gate_tests.py
+++ b/tests/gate_tests.py
@@ -1,23 +1,23 @@
 """
 Unit tests for base Gate class methods
 """
+
 import unittest
 import numpy as np
 
 from flowkit import Dimension
-from .gating_strategy_tests import poly1_gate
-
-test_data_range1 = np.linspace(0.0, 10.0, 101)
+from tests.test_config import poly1_gate
 
 
 class GateTestCase(unittest.TestCase):
     """Tests Gate objects"""
+
     def test_get_gate_dimension(self):
-        dim = poly1_gate.get_dimension('FL2-H')
+        dim = poly1_gate.get_dimension("FL2-H")
 
         self.assertIsInstance(dim, Dimension)
 
     def test_get_gate_dimension_ids(self):
         dim_ids = poly1_gate.get_dimension_ids()
 
-        self.assertListEqual(dim_ids, ['FL2-H', 'FL3-H'])
+        self.assertListEqual(dim_ids, ["FL2-H", "FL3-H"])

--- a/tests/gating_results_tests.py
+++ b/tests/gating_results_tests.py
@@ -4,7 +4,7 @@ Tests for GatingResults class
 import copy
 import unittest
 from flowkit import Workspace
-from .session_tests import test_samples_8c_full_set
+from tests.test_config import test_samples_8c_full_set
 
 wsp_path = "data/8_color_data_set/reused_quad_gate_with_child.wsp"
 group_name = 'All Samples'

--- a/tests/gating_strategy_prog_gate_tests.py
+++ b/tests/gating_strategy_prog_gate_tests.py
@@ -1,6 +1,7 @@
 """
 Tests for programmatically adding gates to a GatingStrategy
 """
+
 import copy
 import unittest
 import numpy as np
@@ -8,209 +9,122 @@ import pandas as pd
 
 import flowkit as fk
 
-data1_fcs_path = 'data/gate_ref/data1.fcs'
-data1_sample = fk.Sample(data1_fcs_path)
-
-poly1_vertices = [
-    [5, 5],
-    [500, 5],
-    [500, 500]
-]
-poly1_dim1 = fk.Dimension('FL2-H', compensation_ref='FCS')
-poly1_dim2 = fk.Dimension('FL3-H', compensation_ref='FCS')
-poly1_dims1 = [poly1_dim1, poly1_dim2]
-poly1_gate = fk.gates.PolygonGate('Polygon1', poly1_dims1, poly1_vertices)
-
-quad1_div1 = fk.QuadrantDivider('FL2', 'FL2-H', 'FCS', [12.14748])
-quad1_div2 = fk.QuadrantDivider('FL4', 'FL4-H', 'FCS', [14.22417])
-quad1_divs = [quad1_div1, quad1_div2]
-
-quad_1 = fk.gates.Quadrant(
-    quadrant_id='FL2P-FL4P',
-    divider_refs=['FL2', 'FL4'],
-    divider_ranges=[(12.14748, None), (14.22417, None)]
-)
-quad_2 = fk.gates.Quadrant(
-    quadrant_id='FL2N-FL4P',
-    divider_refs=['FL2', 'FL4'],
-    divider_ranges=[(None, 12.14748), (14.22417, None)]
-)
-quad_3 = fk.gates.Quadrant(
-    quadrant_id='FL2N-FL4N',
-    divider_refs=['FL2', 'FL4'],
-    divider_ranges=[(None, 12.14748), (None, 14.22417)]
-)
-quad_4 = fk.gates.Quadrant(
-    quadrant_id='FL2P-FL4N',
-    divider_refs=['FL2', 'FL4'],
-    divider_ranges=[(12.14748, None), (None, 14.22417)]
-)
-quadrants_q1 = [quad_1, quad_2, quad_3, quad_4]
-
-quad1_gate = fk.gates.QuadrantGate('Quadrant1', quad1_divs, quadrants_q1)
-
-range1_dim1 = fk.Dimension('FSC-H', compensation_ref='uncompensated', range_min=100)
-range1_dims = [range1_dim1]
-range1_gate = fk.gates.RectangleGate('Range1', range1_dims)
-
-range2_dim1 = fk.Dimension('Time', compensation_ref='uncompensated', range_min=20, range_max=80)
-range2_dims = [range2_dim1]
-range2_gate = fk.gates.RectangleGate('Range2', range2_dims)
-
-ell1_dim1 = fk.Dimension('FL3-H', compensation_ref='uncompensated')
-ell1_dim2 = fk.Dimension('FL4-H', compensation_ref='uncompensated')
-ellipse1_dims = [ell1_dim1, ell1_dim2]
-
-ell1_coords = [12.99701, 16.22941]
-ell1_cov_mat = [[62.5, 37.5], [37.5, 62.5]]
-ell1_dist_square = 1
-
-ellipse1_gate = fk.gates.EllipsoidGate('Ellipse1', ellipse1_dims, ell1_coords, ell1_cov_mat, ell1_dist_square)
-
-spill01_fluoros = ['FITC', 'PE', 'PerCP']
-spill01_detectors = ['FL1-H', 'FL2-H', 'FL3-H']
-spill01_data = np.array(
-    [
-        [1, 0.02, 0.06],
-        [0.11, 1, 0.07],
-        [0.09, 0.01, 1]
-    ]
-)
-comp_matrix_01 = fk.Matrix(spill01_data, spill01_detectors, spill01_fluoros)
-
-asinh_xform_10000_4_1 = fk.transforms.AsinhTransform(
-    param_t=10000,
-    param_m=4,
-    param_a=1
-)
-
-hyperlog_xform_10000__1__4_5__0 = fk.transforms.HyperlogTransform(
-    param_t=10000,
-    param_w=1,
-    param_m=4.5,
-    param_a=0
-)
-
-linear_xform_10000_500 = fk.transforms.LinearTransform(
-    param_t=10000,
-    param_a=500
-)
-
-logicle_xform_10000_0_5__4_5__0 = fk.transforms.LogicleTransform(
-    param_t=10000,
-    param_w=0.5,
-    param_m=4.5,
-    param_a=0
-)
-logicle_xform_10000__0_5__4__0_5 = fk.transforms.LogicleTransform(
-    param_t=10000,
-    param_w=0.5,
-    param_m=4,
-    param_a=0.5
-)
-logicle_xform_10000__1__4__0_5 = fk.transforms.LogicleTransform(
-    param_t=10000,
-    param_w=1,
-    param_m=4,
-    param_a=0.5
+from tests.test_config import (
+    data1_sample,
+    range1_gate,
+    ell1_coords,
+    ell1_cov_mat,
+    ell1_dist_square,
+    asinh_xform_10000_4_1,
+    linear_xform_10000_500,
+    logicle_xform_10000__1__4__0_5,
+    logicle_xform_10000__0_5__4_5__0,
+    poly1_vertices,
+    poly1_gate,
+    ellipse1_gate,
+    range2_gate,
+    quad1_gate,
+    hyperlog_xform_10000__1__4_5__0,
+    comp_matrix_01,
 )
 
 
 class GatingTestCase(unittest.TestCase):
     @staticmethod
     def test_add_min_range_gate():
-        res_path = 'data/gate_ref/truth/Results_Range1.txt'
+        res_path = "data/gate_ref/truth/Results_Range1.txt"
 
         gs = fk.GatingStrategy()
 
-        gs.add_gate(range1_gate, ('root',))
+        gs.add_gate(range1_gate, ("root",))
 
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Range1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Range1"))
 
     @staticmethod
     def test_add_rect1_gate():
         gs = fk.GatingStrategy()
 
-        dim1 = fk.Dimension('SSC-H', compensation_ref='uncompensated', range_min=20, range_max=80)
-        dim2 = fk.Dimension('FL1-H', compensation_ref='uncompensated', range_min=70, range_max=200)
+        dim1 = fk.Dimension(
+            "SSC-H", compensation_ref="uncompensated", range_min=20, range_max=80
+        )
+        dim2 = fk.Dimension(
+            "FL1-H", compensation_ref="uncompensated", range_min=70, range_max=200
+        )
         dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('Rectangle1', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("Rectangle1", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Rectangle1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Rectangle1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Rectangle1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Rectangle1"))
 
     @staticmethod
     def test_add_rect2_gate():
         gs = fk.GatingStrategy()
 
-        dim1 = fk.Dimension('SSC-H', compensation_ref='FCS', range_min=20, range_max=80)
-        dim2 = fk.Dimension('FL1-H', compensation_ref='FCS', range_min=70, range_max=200)
+        dim1 = fk.Dimension("SSC-H", compensation_ref="FCS", range_min=20, range_max=80)
+        dim2 = fk.Dimension(
+            "FL1-H", compensation_ref="FCS", range_min=70, range_max=200
+        )
         dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('Rectangle2', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("Rectangle2", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Rectangle2.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Rectangle2.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Rectangle2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Rectangle2"))
 
     @staticmethod
     def test_add_poly1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(poly1_gate, ('root',))
+        gs.add_gate(poly1_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Polygon1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Polygon1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Polygon1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Polygon1"))
 
     @staticmethod
     def test_add_poly2_gate():
         gs = fk.GatingStrategy()
 
-        dim1 = fk.Dimension('FL1-H', compensation_ref='FCS')
-        dim2 = fk.Dimension('FL4-H', compensation_ref='FCS')
+        dim1 = fk.Dimension("FL1-H", compensation_ref="FCS")
+        dim2 = fk.Dimension("FL4-H", compensation_ref="FCS")
         dims = [dim1, dim2]
 
-        vertices = [
-            [20, 10],
-            [120, 10],
-            [120, 160],
-            [20, 160]
-        ]
+        vertices = [[20, 10], [120, 10], [120, 160], [20, 160]]
 
-        poly_gate = fk.gates.PolygonGate('Polygon2', dims, vertices)
-        gs.add_gate(poly_gate, ('root',))
+        poly_gate = fk.gates.PolygonGate("Polygon2", dims, vertices)
+        gs.add_gate(poly_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Polygon2.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Polygon2.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Polygon2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Polygon2"))
 
     @staticmethod
     def test_add_poly3_non_solid_gate():
         gs = fk.GatingStrategy()
 
-        dim1 = fk.Dimension('SSC-H', compensation_ref='uncompensated')
-        dim2 = fk.Dimension('FL3-H', compensation_ref='FCS')
+        dim1 = fk.Dimension("SSC-H", compensation_ref="uncompensated")
+        dim2 = fk.Dimension("FL3-H", compensation_ref="FCS")
         dims = [dim1, dim2]
 
         vertices = [
@@ -221,1024 +135,1010 @@ class GatingTestCase(unittest.TestCase):
             [100, 180],
             [200, 180],
             [200, 300],
-            [10, 300]
+            [10, 300],
         ]
 
-        poly_gate = fk.gates.PolygonGate('Polygon3NS', dims, vertices)
-        gs.add_gate(poly_gate, ('root',))
+        poly_gate = fk.gates.PolygonGate("Polygon3NS", dims, vertices)
+        gs.add_gate(poly_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Polygon3NS.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Polygon3NS.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Polygon3NS'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Polygon3NS"))
 
     @staticmethod
     def test_add_ellipse1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(ellipse1_gate, ('root',))
+        gs.add_gate(ellipse1_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Ellipse1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Ellipse1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Ellipse1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Ellipse1"))
 
     @staticmethod
     def test_add_ellipsoid_3d_gate():
         gs = fk.GatingStrategy()
 
-        dim1 = fk.Dimension('FL3-H', compensation_ref='FCS')
-        dim2 = fk.Dimension('FL4-H', compensation_ref='FCS')
-        dim3 = fk.Dimension('FL1-H', compensation_ref='FCS')
+        dim1 = fk.Dimension("FL3-H", compensation_ref="FCS")
+        dim2 = fk.Dimension("FL4-H", compensation_ref="FCS")
+        dim3 = fk.Dimension("FL1-H", compensation_ref="FCS")
         dims = [dim1, dim2, dim3]
 
         coords = [40.3, 30.6, 20.8]
         cov_mat = [[2.5, 7.5, 17.5], [7.5, 7.0, 13.5], [15.5, 13.5, 4.3]]
         dist_square = 1
 
-        poly_gate = fk.gates.EllipsoidGate('Ellipsoid3D', dims, coords, cov_mat, dist_square)
-        gs.add_gate(poly_gate, ('root',))
+        poly_gate = fk.gates.EllipsoidGate(
+            "Ellipsoid3D", dims, coords, cov_mat, dist_square
+        )
+        gs.add_gate(poly_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Ellipsoid3D.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Ellipsoid3D.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Ellipsoid3D'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Ellipsoid3D"))
 
     @staticmethod
     def test_add_time_range_gate():
-        res_path = 'data/gate_ref/truth/Results_Range2.txt'
+        res_path = "data/gate_ref/truth/Results_Range2.txt"
 
         gs = fk.GatingStrategy()
 
-        gs.add_gate(range2_gate, ('root',))
+        gs.add_gate(range2_gate, ("root",))
 
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Range2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Range2"))
 
     @staticmethod
     def test_add_quadrant1_gate():
-        res1_path = 'data/gate_ref/truth/Results_FL2N-FL4N.txt'
-        res2_path = 'data/gate_ref/truth/Results_FL2N-FL4P.txt'
-        res3_path = 'data/gate_ref/truth/Results_FL2P-FL4N.txt'
-        res4_path = 'data/gate_ref/truth/Results_FL2P-FL4P.txt'
+        res1_path = "data/gate_ref/truth/Results_FL2N-FL4N.txt"
+        res2_path = "data/gate_ref/truth/Results_FL2N-FL4P.txt"
+        res3_path = "data/gate_ref/truth/Results_FL2P-FL4N.txt"
+        res4_path = "data/gate_ref/truth/Results_FL2P-FL4P.txt"
 
         gs = fk.GatingStrategy()
 
-        gs.add_gate(quad1_gate, ('root',))
+        gs.add_gate(quad1_gate, ("root",))
 
-        truth1 = pd.read_csv(res1_path, header=None, dtype='bool').squeeze().values
-        truth2 = pd.read_csv(res2_path, header=None, dtype='bool').squeeze().values
-        truth3 = pd.read_csv(res3_path, header=None, dtype='bool').squeeze().values
-        truth4 = pd.read_csv(res4_path, header=None, dtype='bool').squeeze().values
+        truth1 = pd.read_csv(res1_path, header=None, dtype="bool").squeeze().values
+        truth2 = pd.read_csv(res2_path, header=None, dtype="bool").squeeze().values
+        truth3 = pd.read_csv(res3_path, header=None, dtype="bool").squeeze().values
+        truth4 = pd.read_csv(res4_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth1, result.get_gate_membership('FL2N-FL4N'))
-        np.testing.assert_array_equal(truth2, result.get_gate_membership('FL2N-FL4P'))
-        np.testing.assert_array_equal(truth3, result.get_gate_membership('FL2P-FL4N'))
-        np.testing.assert_array_equal(truth4, result.get_gate_membership('FL2P-FL4P'))
+        np.testing.assert_array_equal(truth1, result.get_gate_membership("FL2N-FL4N"))
+        np.testing.assert_array_equal(truth2, result.get_gate_membership("FL2N-FL4P"))
+        np.testing.assert_array_equal(truth3, result.get_gate_membership("FL2P-FL4N"))
+        np.testing.assert_array_equal(truth4, result.get_gate_membership("FL2P-FL4P"))
 
     def test_add_quadrant_gate_relative_percent(self):
         gs = fk.GatingStrategy()
 
-        gs.add_gate(quad1_gate, ('root',))
+        gs.add_gate(quad1_gate, ("root",))
 
         result = gs.gate_sample(data1_sample)
 
-        total_percent = result.get_gate_relative_percent('FL2N-FL4N') + \
-            result.get_gate_relative_percent('FL2N-FL4P') + \
-            result.get_gate_relative_percent('FL2P-FL4N') + \
-            result.get_gate_relative_percent('FL2P-FL4P')
+        total_percent = (
+            result.get_gate_relative_percent("FL2N-FL4N")
+            + result.get_gate_relative_percent("FL2N-FL4P")
+            + result.get_gate_relative_percent("FL2P-FL4N")
+            + result.get_gate_relative_percent("FL2P-FL4P")
+        )
 
         self.assertEqual(100.0, total_percent)
 
     @staticmethod
     def test_add_quadrant2_gate():
-        res1_path = 'data/gate_ref/truth/Results_FSCN-SSCN.txt'
-        res2_path = 'data/gate_ref/truth/Results_FSCD-SSCN-FL1N.txt'
-        res3_path = 'data/gate_ref/truth/Results_FSCP-SSCN-FL1N.txt'
-        res4_path = 'data/gate_ref/truth/Results_FSCD-FL1P.txt'
-        res5_path = 'data/gate_ref/truth/Results_FSCN-SSCP-FL1P.txt'
+        res1_path = "data/gate_ref/truth/Results_FSCN-SSCN.txt"
+        res2_path = "data/gate_ref/truth/Results_FSCD-SSCN-FL1N.txt"
+        res3_path = "data/gate_ref/truth/Results_FSCP-SSCN-FL1N.txt"
+        res4_path = "data/gate_ref/truth/Results_FSCD-FL1P.txt"
+        res5_path = "data/gate_ref/truth/Results_FSCN-SSCP-FL1P.txt"
 
-        truth1 = pd.read_csv(res1_path, header=None, dtype='bool').squeeze().values
-        truth2 = pd.read_csv(res2_path, header=None, dtype='bool').squeeze().values
-        truth3 = pd.read_csv(res3_path, header=None, dtype='bool').squeeze().values
-        truth4 = pd.read_csv(res4_path, header=None, dtype='bool').squeeze().values
-        truth5 = pd.read_csv(res5_path, header=None, dtype='bool').squeeze().values
+        truth1 = pd.read_csv(res1_path, header=None, dtype="bool").squeeze().values
+        truth2 = pd.read_csv(res2_path, header=None, dtype="bool").squeeze().values
+        truth3 = pd.read_csv(res3_path, header=None, dtype="bool").squeeze().values
+        truth4 = pd.read_csv(res4_path, header=None, dtype="bool").squeeze().values
+        truth5 = pd.read_csv(res5_path, header=None, dtype="bool").squeeze().values
 
         gs = fk.GatingStrategy()
 
-        div1 = fk.QuadrantDivider('FSC', 'FSC-H', 'uncompensated', [28.0654, 70.02725])
-        div2 = fk.QuadrantDivider('SSC', 'SSC-H', 'uncompensated', [17.75])
-        div3 = fk.QuadrantDivider('FL1', 'FL1-H', 'uncompensated', [6.43567])
+        div1 = fk.QuadrantDivider("FSC", "FSC-H", "uncompensated", [28.0654, 70.02725])
+        div2 = fk.QuadrantDivider("SSC", "SSC-H", "uncompensated", [17.75])
+        div3 = fk.QuadrantDivider("FL1", "FL1-H", "uncompensated", [6.43567])
 
         divs = [div1, div2, div3]
 
         q2_quad_1 = fk.gates.Quadrant(
-            quadrant_id='FSCD-FL1P',
-            divider_refs=['FSC', 'FL1'],
-            divider_ranges=[(28.0654, 70.02725), (6.43567, None)]
+            quadrant_id="FSCD-FL1P",
+            divider_refs=["FSC", "FL1"],
+            divider_ranges=[(28.0654, 70.02725), (6.43567, None)],
         )
         q2_quad_2 = fk.gates.Quadrant(
-            quadrant_id='FSCD-SSCN-FL1N',
-            divider_refs=['FSC', 'SSC', 'FL1'],
-            divider_ranges=[(28.0654, 70.02725), (None, 17.75), (None, 6.43567)]
+            quadrant_id="FSCD-SSCN-FL1N",
+            divider_refs=["FSC", "SSC", "FL1"],
+            divider_ranges=[(28.0654, 70.02725), (None, 17.75), (None, 6.43567)],
         )
         q2_quad_3 = fk.gates.Quadrant(
-            quadrant_id='FSCN-SSCN',
-            divider_refs=['FSC', 'SSC'],
-            divider_ranges=[(None, 28.0654), (None, 17.75)]
+            quadrant_id="FSCN-SSCN",
+            divider_refs=["FSC", "SSC"],
+            divider_ranges=[(None, 28.0654), (None, 17.75)],
         )
         q2_quad_4 = fk.gates.Quadrant(
-            quadrant_id='FSCN-SSCP-FL1P',
-            divider_refs=['FSC', 'SSC', 'FL1'],
-            divider_ranges=[(None, 28.0654), (17.75, None), (6.43567, None)]
+            quadrant_id="FSCN-SSCP-FL1P",
+            divider_refs=["FSC", "SSC", "FL1"],
+            divider_ranges=[(None, 28.0654), (17.75, None), (6.43567, None)],
         )
         q2_quad_5 = fk.gates.Quadrant(
-            quadrant_id='FSCP-SSCN-FL1N',
-            divider_refs=['FSC', 'SSC', 'FL1'],
-            divider_ranges=[(70.02725, None), (None, 17.75), (None, 6.43567)]
+            quadrant_id="FSCP-SSCN-FL1N",
+            divider_refs=["FSC", "SSC", "FL1"],
+            divider_ranges=[(70.02725, None), (None, 17.75), (None, 6.43567)],
         )
 
         quadrants_q2 = [q2_quad_1, q2_quad_2, q2_quad_3, q2_quad_4, q2_quad_5]
 
-        quad_gate = fk.gates.QuadrantGate('Quadrant2', divs, quadrants_q2)
-        gs.add_gate(quad_gate, ('root',))
+        quad_gate = fk.gates.QuadrantGate("Quadrant2", divs, quadrants_q2)
+        gs.add_gate(quad_gate, ("root",))
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth1, result.get_gate_membership('FSCN-SSCN'))
-        np.testing.assert_array_equal(truth2, result.get_gate_membership('FSCD-SSCN-FL1N'))
-        np.testing.assert_array_equal(truth3, result.get_gate_membership('FSCP-SSCN-FL1N'))
-        np.testing.assert_array_equal(truth4, result.get_gate_membership('FSCD-FL1P'))
-        np.testing.assert_array_equal(truth5, result.get_gate_membership('FSCN-SSCP-FL1P'))
+        np.testing.assert_array_equal(truth1, result.get_gate_membership("FSCN-SSCN"))
+        np.testing.assert_array_equal(
+            truth2, result.get_gate_membership("FSCD-SSCN-FL1N")
+        )
+        np.testing.assert_array_equal(
+            truth3, result.get_gate_membership("FSCP-SSCN-FL1N")
+        )
+        np.testing.assert_array_equal(truth4, result.get_gate_membership("FSCD-FL1P"))
+        np.testing.assert_array_equal(
+            truth5, result.get_gate_membership("FSCN-SSCP-FL1P")
+        )
 
     @staticmethod
     def test_add_ratio_range1_gate():
         gs = fk.GatingStrategy()
 
         rat_xform_fl2h_fl2a = fk.transforms.RatioTransform(
-            ['FL2-H', 'FL2-A'],
-            param_a=1,
-            param_b=0,
-            param_c=-1
+            ["FL2-H", "FL2-A"], param_a=1, param_b=0, param_c=-1
         )
-        gs.add_transform('FL2Rat1', rat_xform_fl2h_fl2a)
+        gs.add_transform("FL2Rat1", rat_xform_fl2h_fl2a)
 
         dim_rat1 = fk.RatioDimension(
-            'FL2Rat1',
-            compensation_ref='uncompensated',
-            range_min=3,
-            range_max=16.4
+            "FL2Rat1", compensation_ref="uncompensated", range_min=3, range_max=16.4
         )
         dims = [dim_rat1]
 
-        rect_gate = fk.gates.RectangleGate('RatRange1', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("RatRange1", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_RatRange1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_RatRange1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('RatRange1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("RatRange1"))
 
     @staticmethod
     def test_add_ratio_range2_gate():
         gs = fk.GatingStrategy()
 
         rat_xform_fl2h_fl2a = fk.transforms.RatioTransform(
-            ['FL2-H', 'FL2-A'],
-            param_a=2.7,
-            param_b=-100,
-            param_c=-300
+            ["FL2-H", "FL2-A"], param_a=2.7, param_b=-100, param_c=-300
         )
-        gs.add_transform('FL2Rat2', rat_xform_fl2h_fl2a)
+        gs.add_transform("FL2Rat2", rat_xform_fl2h_fl2a)
 
         dim_rat2 = fk.RatioDimension(
-            'FL2Rat2',
-            compensation_ref='uncompensated',
-            range_min=0.95,
-            range_max=1.05
+            "FL2Rat2", compensation_ref="uncompensated", range_min=0.95, range_max=1.05
         )
         dims = [dim_rat2]
 
-        rect_gate = fk.gates.RectangleGate('RatRange2', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("RatRange2", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_RatRange2.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_RatRange2.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('RatRange2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("RatRange2"))
 
     @staticmethod
     def test_add_log_ratio_range1_gate():
         gs = fk.GatingStrategy()
 
         rat_xform_fl2h_fl2a = fk.transforms.RatioTransform(
-            ['FL2-H', 'FL2-A'],
-            param_a=1,
-            param_b=0,
-            param_c=-1
+            ["FL2-H", "FL2-A"], param_a=1, param_b=0, param_c=-1
         )
-        gs.add_transform('FL2Rat1', rat_xform_fl2h_fl2a)
+        gs.add_transform("FL2Rat1", rat_xform_fl2h_fl2a)
 
         log_rat_xform = fk.transforms.LogTransform(param_t=100, param_m=2)
-        gs.add_transform('MyRatLog',log_rat_xform)
+        gs.add_transform("MyRatLog", log_rat_xform)
 
         dim_rat1 = fk.RatioDimension(
-            'FL2Rat1',
-            compensation_ref='uncompensated',
-            transformation_ref='MyRatLog',
+            "FL2Rat1",
+            compensation_ref="uncompensated",
+            transformation_ref="MyRatLog",
             range_min=0.40625,
-            range_max=0.6601562
+            range_max=0.6601562,
         )
         dims = [dim_rat1]
 
-        rect_gate = fk.gates.RectangleGate('RatRange1a', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("RatRange1a", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_RatRange1a.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_RatRange1a.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('RatRange1a'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("RatRange1a"))
 
     @staticmethod
     def test_add_boolean_and1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(poly1_gate, ('root',))
-        gs.add_gate(range2_gate, ('root',))
+        gs.add_gate(poly1_gate, ("root",))
+        gs.add_gate(range2_gate, ("root",))
 
         gate_refs = [
-            {
-                'ref': 'Polygon1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Range2',
-                'path': ('root',),
-                'complement': False
-            }
+            {"ref": "Polygon1", "path": ("root",), "complement": False},
+            {"ref": "Range2", "path": ("root",), "complement": False},
         ]
 
-        bool_gate = fk.gates.BooleanGate('And1', 'and', gate_refs)
-        gs.add_gate(bool_gate, ('root',))
+        bool_gate = fk.gates.BooleanGate("And1", "and", gate_refs)
+        gs.add_gate(bool_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_And1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_And1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('And1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("And1"))
 
     @staticmethod
     def test_add_boolean_and2_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(range1_gate, ('root',))
-        gs.add_gate(poly1_gate, ('root',))
-        gs.add_gate(ellipse1_gate, ('root',))
+        gs.add_gate(range1_gate, ("root",))
+        gs.add_gate(poly1_gate, ("root",))
+        gs.add_gate(ellipse1_gate, ("root",))
 
         gate_refs = [
-            {
-                'ref': 'Range1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Ellipse1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Polygon1',
-                'path': ('root',),
-                'complement': False
-            }
+            {"ref": "Range1", "path": ("root",), "complement": False},
+            {"ref": "Ellipse1", "path": ("root",), "complement": False},
+            {"ref": "Polygon1", "path": ("root",), "complement": False},
         ]
 
-        bool_gate = fk.gates.BooleanGate('And2', 'and', gate_refs)
-        gs.add_gate(bool_gate, ('root',))
+        bool_gate = fk.gates.BooleanGate("And2", "and", gate_refs)
+        gs.add_gate(bool_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_And2.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_And2.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('And2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("And2"))
 
     @staticmethod
     def test_add_boolean_or1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(range1_gate, ('root',))
-        gs.add_gate(poly1_gate, ('root',))
-        gs.add_gate(ellipse1_gate, ('root',))
+        gs.add_gate(range1_gate, ("root",))
+        gs.add_gate(poly1_gate, ("root",))
+        gs.add_gate(ellipse1_gate, ("root",))
 
         gate_refs = [
-            {
-                'ref': 'Range1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Ellipse1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Polygon1',
-                'path': ('root',),
-                'complement': False
-            }
+            {"ref": "Range1", "path": ("root",), "complement": False},
+            {"ref": "Ellipse1", "path": ("root",), "complement": False},
+            {"ref": "Polygon1", "path": ("root",), "complement": False},
         ]
 
-        bool_gate = fk.gates.BooleanGate('Or1', 'or', gate_refs)
-        gs.add_gate(bool_gate, ('root',))
+        bool_gate = fk.gates.BooleanGate("Or1", "or", gate_refs)
+        gs.add_gate(bool_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Or1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Or1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Or1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Or1"))
 
     @staticmethod
     def test_add_boolean_and3_complement_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(range1_gate, ('root',))
-        gs.add_gate(poly1_gate, ('root',))
-        gs.add_gate(ellipse1_gate, ('root',))
+        gs.add_gate(range1_gate, ("root",))
+        gs.add_gate(poly1_gate, ("root",))
+        gs.add_gate(ellipse1_gate, ("root",))
 
         gate_refs = [
-            {
-                'ref': 'Range1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Ellipse1',
-                'path': ('root',),
-                'complement': True
-            },
-            {
-                'ref': 'Polygon1',
-                'path': ('root',),
-                'complement': False
-            }
+            {"ref": "Range1", "path": ("root",), "complement": False},
+            {"ref": "Ellipse1", "path": ("root",), "complement": True},
+            {"ref": "Polygon1", "path": ("root",), "complement": False},
         ]
 
-        bool_gate = fk.gates.BooleanGate('And3', 'and', gate_refs)
-        gs.add_gate(bool_gate, ('root',))
+        bool_gate = fk.gates.BooleanGate("And3", "and", gate_refs)
+        gs.add_gate(bool_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_And3.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_And3.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('And3'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("And3"))
 
     @staticmethod
     def test_add_boolean_not1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(ellipse1_gate, ('root',))
+        gs.add_gate(ellipse1_gate, ("root",))
 
-        gate_refs = [
-            {
-                'ref': 'Ellipse1',
-                'path': ('root',),
-                'complement': False
-            }
-        ]
+        gate_refs = [{"ref": "Ellipse1", "path": ("root",), "complement": False}]
 
-        bool_gate = fk.gates.BooleanGate('Not1', 'not', gate_refs)
-        gs.add_gate(bool_gate, ('root',))
+        bool_gate = fk.gates.BooleanGate("Not1", "not", gate_refs)
+        gs.add_gate(bool_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Not1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Not1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Not1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Not1"))
 
     @staticmethod
     def test_add_boolean_and4_not_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(range1_gate, ('root',))
-        gs.add_gate(poly1_gate, ('root',))
-        gs.add_gate(ellipse1_gate, ('root',))
+        gs.add_gate(range1_gate, ("root",))
+        gs.add_gate(poly1_gate, ("root",))
+        gs.add_gate(ellipse1_gate, ("root",))
 
-        gate1_refs = [
-            {
-                'ref': 'Ellipse1',
-                'path': ('root',),
-                'complement': False
-            }
-        ]
+        gate1_refs = [{"ref": "Ellipse1", "path": ("root",), "complement": False}]
 
-        bool1_gate = fk.gates.BooleanGate('Not1', 'not', gate1_refs)
-        gs.add_gate(bool1_gate, ('root',))
+        bool1_gate = fk.gates.BooleanGate("Not1", "not", gate1_refs)
+        gs.add_gate(bool1_gate, ("root",))
 
         gate2_refs = [
-            {
-                'ref': 'Range1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Not1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Polygon1',
-                'path': ('root',),
-                'complement': False
-            }
+            {"ref": "Range1", "path": ("root",), "complement": False},
+            {"ref": "Not1", "path": ("root",), "complement": False},
+            {"ref": "Polygon1", "path": ("root",), "complement": False},
         ]
 
-        bool2_gate = fk.gates.BooleanGate('And4', 'and', gate2_refs)
-        gs.add_gate(bool2_gate, ('root',))
+        bool2_gate = fk.gates.BooleanGate("And4", "and", gate2_refs)
+        gs.add_gate(bool2_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_And4.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_And4.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('And4'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("And4"))
 
     @staticmethod
     def test_add_boolean_or2_complement_gate():
         gs = fk.GatingStrategy()
 
-        dim1 = fk.Dimension('SSC-H', compensation_ref='FCS', range_min=20, range_max=80)
-        dim2 = fk.Dimension('FL1-H', compensation_ref='FCS', range_min=70, range_max=200)
+        dim1 = fk.Dimension("SSC-H", compensation_ref="FCS", range_min=20, range_max=80)
+        dim2 = fk.Dimension(
+            "FL1-H", compensation_ref="FCS", range_min=70, range_max=200
+        )
         rect_dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('Rectangle2', rect_dims)
-        gs.add_gate(rect_gate, ('root',))
-        gs.add_gate(quad1_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("Rectangle2", rect_dims)
+        gs.add_gate(rect_gate, ("root",))
+        gs.add_gate(quad1_gate, ("root",))
 
         gate1_refs = [
-            {
-                'ref': 'Rectangle2',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'FL2N-FL4N',
-                'path': ('root', 'Quadrant1'),
-                'complement': True
-            }
+            {"ref": "Rectangle2", "path": ("root",), "complement": False},
+            {"ref": "FL2N-FL4N", "path": ("root", "Quadrant1"), "complement": True},
         ]
 
-        bool1_gate = fk.gates.BooleanGate('Or2', 'or', gate1_refs)
-        gs.add_gate(bool1_gate, ('root',))
+        bool1_gate = fk.gates.BooleanGate("Or2", "or", gate1_refs)
+        gs.add_gate(bool1_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Or2.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Or2.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Or2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Or2"))
 
     @staticmethod
     def test_add_matrix_poly4_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        dim1 = fk.Dimension('PE', compensation_ref='MySpill')
-        dim2 = fk.Dimension('PerCP', compensation_ref='MySpill')
+        dim1 = fk.Dimension("PE", compensation_ref="MySpill")
+        dim2 = fk.Dimension("PerCP", compensation_ref="MySpill")
         dims = [dim1, dim2]
 
-        poly_gate = fk.gates.PolygonGate('Polygon4', dims, poly1_vertices)
-        gs.add_gate(poly_gate, ('root',))
+        poly_gate = fk.gates.PolygonGate("Polygon4", dims, poly1_vertices)
+        gs.add_gate(poly_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Polygon4.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Polygon4.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Polygon4'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Polygon4"))
 
     @staticmethod
     def test_add_matrix_rect3_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        dim1 = fk.Dimension('FITC', compensation_ref='MySpill', range_min=5, range_max=70)
-        dim2 = fk.Dimension('PE', compensation_ref='MySpill', range_min=9, range_max=208)
+        dim1 = fk.Dimension(
+            "FITC", compensation_ref="MySpill", range_min=5, range_max=70
+        )
+        dim2 = fk.Dimension(
+            "PE", compensation_ref="MySpill", range_min=9, range_max=208
+        )
         dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('Rectangle3', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("Rectangle3", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Rectangle3.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Rectangle3.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Rectangle3'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Rectangle3"))
 
     @staticmethod
     def test_add_matrix_rect4_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        dim1 = fk.Dimension('PerCP', compensation_ref='MySpill', range_min=7, range_max=90)
-        dim2 = fk.Dimension('FSC-H', compensation_ref='uncompensated', range_min=10, range_max=133)
+        dim1 = fk.Dimension(
+            "PerCP", compensation_ref="MySpill", range_min=7, range_max=90
+        )
+        dim2 = fk.Dimension(
+            "FSC-H", compensation_ref="uncompensated", range_min=10, range_max=133
+        )
         dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('Rectangle4', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("Rectangle4", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Rectangle4.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Rectangle4.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Rectangle4'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Rectangle4"))
 
     @staticmethod
     def test_add_matrix_rect5_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        dim1 = fk.Dimension('PerCP', compensation_ref='MySpill', range_min=7, range_max=90)
-        dim2 = fk.Dimension('FSC-H', compensation_ref='uncompensated', range_min=10)
+        dim1 = fk.Dimension(
+            "PerCP", compensation_ref="MySpill", range_min=7, range_max=90
+        )
+        dim2 = fk.Dimension("FSC-H", compensation_ref="uncompensated", range_min=10)
         dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('Rectangle5', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("Rectangle5", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Rectangle5.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Rectangle5.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Rectangle5'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Rectangle5"))
 
     @staticmethod
     def test_add_transform_asinh_range1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_transform('AsinH_10000_4_1', asinh_xform_10000_4_1)
+        gs.add_transform("AsinH_10000_4_1", asinh_xform_10000_4_1)
 
-        dim1 = fk.Dimension('FL1-H', 'uncompensated', 'AsinH_10000_4_1', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FL1-H", "uncompensated", "AsinH_10000_4_1", range_min=0.37, range_max=0.63
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange1', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange1", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange1"))
 
     @staticmethod
     def test_add_transform_hyperlog_range2_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_transform('Hyperlog_10000_1_4.5_0', hyperlog_xform_10000__1__4_5__0)
+        gs.add_transform("Hyperlog_10000_1_4.5_0", hyperlog_xform_10000__1__4_5__0)
 
-        dim1 = fk.Dimension('FL1-H', 'uncompensated', 'Hyperlog_10000_1_4.5_0', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FL1-H",
+            "uncompensated",
+            "Hyperlog_10000_1_4.5_0",
+            range_min=0.37,
+            range_max=0.63,
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange2', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange2", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange2.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange2.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange2"))
 
     @staticmethod
     def test_add_transform_linear_range3_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_transform('Linear_10000_500', linear_xform_10000_500)
+        gs.add_transform("Linear_10000_500", linear_xform_10000_500)
 
-        dim1 = fk.Dimension('FL1-H', 'uncompensated', 'Linear_10000_500', range_min=0.049, range_max=0.055)
+        dim1 = fk.Dimension(
+            "FL1-H",
+            "uncompensated",
+            "Linear_10000_500",
+            range_min=0.049,
+            range_max=0.055,
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange3', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange3", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange3.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange3.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange3'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange3"))
 
     @staticmethod
     def test_add_transform_logicle_range4_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_transform('Logicle_10000_0.5_4.5_0', logicle_xform_10000_0_5__4_5__0)
+        gs.add_transform("Logicle_10000_0.5_4.5_0", logicle_xform_10000__0_5__4_5__0)
 
-        dim1 = fk.Dimension('FL1-H', 'uncompensated', 'Logicle_10000_0.5_4.5_0', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FL1-H",
+            "uncompensated",
+            "Logicle_10000_0.5_4.5_0",
+            range_min=0.37,
+            range_max=0.63,
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange4', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange4", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange4.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange4.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange4'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange4"))
 
     @staticmethod
     def test_add_transform_logicle_range5_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_transform('Logicle_10000_1_4_0.5', logicle_xform_10000__1__4__0_5)
+        gs.add_transform("Logicle_10000_1_4_0.5", logicle_xform_10000__1__4__0_5)
 
-        dim1 = fk.Dimension('FL1-H', 'uncompensated', 'Logicle_10000_1_4_0.5', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FL1-H",
+            "uncompensated",
+            "Logicle_10000_1_4_0.5",
+            range_min=0.37,
+            range_max=0.63,
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange5', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange5", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange5.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange5.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange5'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange5"))
 
     @staticmethod
     def test_add_transform_log_range6_gate():
         gs = fk.GatingStrategy()
 
-        xform = fk.transforms.LogTransform(
-            param_t=10000,
-            param_m=5
-        )
-        gs.add_transform('Logarithmic_10000_5', xform)
+        xform = fk.transforms.LogTransform(param_t=10000, param_m=5)
+        gs.add_transform("Logarithmic_10000_5", xform)
 
-        dim1 = fk.Dimension('FL1-H', 'uncompensated', 'Logarithmic_10000_5', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FL1-H",
+            "uncompensated",
+            "Logarithmic_10000_5",
+            range_min=0.37,
+            range_max=0.63,
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange6', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange6", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange6.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange6.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange6'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange6"))
 
     @staticmethod
     def test_add_matrix_transform_asinh_range1c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('AsinH_10000_4_1', asinh_xform_10000_4_1)
+        gs.add_transform("AsinH_10000_4_1", asinh_xform_10000_4_1)
 
-        dim1 = fk.Dimension('FITC', 'MySpill', 'AsinH_10000_4_1', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FITC", "MySpill", "AsinH_10000_4_1", range_min=0.37, range_max=0.63
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange1c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange1c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange1c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange1c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange1c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange1c"))
 
     @staticmethod
     def test_add_matrix_transform_hyperlog_range2c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Hyperlog_10000_1_4.5_0', hyperlog_xform_10000__1__4_5__0)
+        gs.add_transform("Hyperlog_10000_1_4.5_0", hyperlog_xform_10000__1__4_5__0)
 
-        dim1 = fk.Dimension('FITC', 'MySpill', 'Hyperlog_10000_1_4.5_0', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FITC", "MySpill", "Hyperlog_10000_1_4.5_0", range_min=0.37, range_max=0.63
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange2c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange2c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange2c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange2c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange2c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange2c"))
 
     @staticmethod
     def test_add_matrix_transform_linear_range3c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Linear_10000_500', linear_xform_10000_500)
+        gs.add_transform("Linear_10000_500", linear_xform_10000_500)
 
-        dim1 = fk.Dimension('FITC', 'MySpill', 'Linear_10000_500', range_min=0.049, range_max=0.055)
+        dim1 = fk.Dimension(
+            "FITC", "MySpill", "Linear_10000_500", range_min=0.049, range_max=0.055
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange3c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange3c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange3c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange3c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange3c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange3c"))
 
     @staticmethod
     def test_add_matrix_transform_logicle_range4c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Logicle_10000_0.5_4.5_0', logicle_xform_10000_0_5__4_5__0)
+        gs.add_transform("Logicle_10000_0.5_4.5_0", logicle_xform_10000__0_5__4_5__0)
 
-        dim1 = fk.Dimension('FITC', 'MySpill', 'Logicle_10000_0.5_4.5_0', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FITC", "MySpill", "Logicle_10000_0.5_4.5_0", range_min=0.37, range_max=0.63
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange4c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange4c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange4c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange4c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange4c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange4c"))
 
     @staticmethod
     def test_add_matrix_transform_logicle_range5c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Logicle_10000_1_4_0.5', logicle_xform_10000__1__4__0_5)
+        gs.add_transform("Logicle_10000_1_4_0.5", logicle_xform_10000__1__4__0_5)
 
-        dim1 = fk.Dimension('FITC', 'MySpill', 'Logicle_10000_1_4_0.5', range_min=0.37, range_max=0.63)
+        dim1 = fk.Dimension(
+            "FITC", "MySpill", "Logicle_10000_1_4_0.5", range_min=0.37, range_max=0.63
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange5c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange5c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange5c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange5c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange5c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange5c"))
 
     @staticmethod
     def test_add_matrix_transform_asinh_range6c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('AsinH_10000_4_1', asinh_xform_10000_4_1)
+        gs.add_transform("AsinH_10000_4_1", asinh_xform_10000_4_1)
 
-        dim1 = fk.Dimension('PE', 'MySpill', 'AsinH_10000_4_1', range_min=0.09, range_max=0.36)
+        dim1 = fk.Dimension(
+            "PE", "MySpill", "AsinH_10000_4_1", range_min=0.09, range_max=0.36
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange6c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange6c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange6c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange6c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange6c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange6c"))
 
     @staticmethod
     def test_add_matrix_transform_hyperlog_range7c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Hyperlog_10000_1_4.5_0', hyperlog_xform_10000__1__4_5__0)
+        gs.add_transform("Hyperlog_10000_1_4.5_0", hyperlog_xform_10000__1__4_5__0)
 
-        dim1 = fk.Dimension('PE', 'MySpill', 'Hyperlog_10000_1_4.5_0', range_min=0.09, range_max=0.36)
+        dim1 = fk.Dimension(
+            "PE", "MySpill", "Hyperlog_10000_1_4.5_0", range_min=0.09, range_max=0.36
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange7c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange7c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange7c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange7c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange7c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange7c"))
 
     @staticmethod
     def test_add_matrix_transform_logicle_range8c_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Logicle_10000_1_4_0.5', logicle_xform_10000__1__4__0_5)
+        gs.add_transform("Logicle_10000_1_4_0.5", logicle_xform_10000__1__4__0_5)
 
-        dim1 = fk.Dimension('PE', 'MySpill', 'Logicle_10000_1_4_0.5', range_min=0.09, range_max=0.36)
+        dim1 = fk.Dimension(
+            "PE", "MySpill", "Logicle_10000_1_4_0.5", range_min=0.09, range_max=0.36
+        )
         dims = [dim1]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRange8c', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRange8c", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange8c.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange8c.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange8c'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange8c"))
 
     @staticmethod
     def test_add_matrix_transform_logicle_rect1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Logicle_10000_0.5_4.5_0', logicle_xform_10000_0_5__4_5__0)
+        gs.add_transform("Logicle_10000_0.5_4.5_0", logicle_xform_10000__0_5__4_5__0)
 
-        dim1 = fk.Dimension('PE', 'MySpill', 'Logicle_10000_0.5_4.5_0', range_min=0.31, range_max=0.69)
-        dim2 = fk.Dimension('PerCP', 'MySpill', 'Logicle_10000_0.5_4.5_0', range_min=0.27, range_max=0.73)
+        dim1 = fk.Dimension(
+            "PE", "MySpill", "Logicle_10000_0.5_4.5_0", range_min=0.31, range_max=0.69
+        )
+        dim2 = fk.Dimension(
+            "PerCP",
+            "MySpill",
+            "Logicle_10000_0.5_4.5_0",
+            range_min=0.27,
+            range_max=0.73,
+        )
         dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('ScaleRect1', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("ScaleRect1", dims)
+        gs.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRect1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRect1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRect1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRect1"))
 
     @staticmethod
     def test_add_parent_poly1_boolean_and2_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(poly1_gate, ('root',))
+        gs.add_gate(poly1_gate, ("root",))
 
-        dim3 = fk.Dimension('FL3-H', compensation_ref='FCS')
-        dim4 = fk.Dimension('FL4-H', compensation_ref='FCS')
+        dim3 = fk.Dimension("FL3-H", compensation_ref="FCS")
+        dim4 = fk.Dimension("FL4-H", compensation_ref="FCS")
         dims2 = [dim3, dim4]
 
-        ellipse_gate = fk.gates.EllipsoidGate('Ellipse1', dims2, ell1_coords, ell1_cov_mat, ell1_dist_square)
-        gs.add_gate(ellipse_gate, ('root',))
-        gs.add_gate(range1_gate, ('root',))
+        ellipse_gate = fk.gates.EllipsoidGate(
+            "Ellipse1", dims2, ell1_coords, ell1_cov_mat, ell1_dist_square
+        )
+        gs.add_gate(ellipse_gate, ("root",))
+        gs.add_gate(range1_gate, ("root",))
 
         gate_refs = [
-            {
-                'ref': 'Range1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Ellipse1',
-                'path': ('root',),
-                'complement': False
-            }
+            {"ref": "Range1", "path": ("root",), "complement": False},
+            {"ref": "Ellipse1", "path": ("root",), "complement": False},
         ]
 
-        bool_gate = fk.gates.BooleanGate('ParAnd2', 'and', gate_refs)
-        gs.add_gate(bool_gate, ('root', 'Polygon1'))
+        bool_gate = fk.gates.BooleanGate("ParAnd2", "and", gate_refs)
+        gs.add_gate(bool_gate, ("root", "Polygon1"))
 
-        res_path = 'data/gate_ref/truth/Results_ParAnd2.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ParAnd2.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ParAnd2'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ParAnd2"))
 
     @staticmethod
     def test_add_parent_range1_boolean_and3_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_gate(poly1_gate, ('root',))
-        gs.add_gate(ellipse1_gate, ('root',))
-        gs.add_gate(range1_gate, ('root',))
+        gs.add_gate(poly1_gate, ("root",))
+        gs.add_gate(ellipse1_gate, ("root",))
+        gs.add_gate(range1_gate, ("root",))
 
         gate_refs = [
-            {
-                'ref': 'Polygon1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Ellipse1',
-                'path': ('root',),
-                'complement': True
-            }
+            {"ref": "Polygon1", "path": ("root",), "complement": False},
+            {"ref": "Ellipse1", "path": ("root",), "complement": True},
         ]
 
-        bool_gate = fk.gates.BooleanGate('ParAnd3', 'and', gate_refs)
-        gs.add_gate(bool_gate, ('root', 'Range1'))
+        bool_gate = fk.gates.BooleanGate("ParAnd3", "and", gate_refs)
+        gs.add_gate(bool_gate, ("root", "Range1"))
 
-        res_path = 'data/gate_ref/truth/Results_ParAnd3.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ParAnd3.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ParAnd3'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ParAnd3"))
 
     @staticmethod
     def test_add_parent_rect1_rect_par1_gate():
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Logicle_10000_0.5_4.5_0', logicle_xform_10000_0_5__4_5__0)
-        gs.add_transform('Hyperlog_10000_1_4.5_0', hyperlog_xform_10000__1__4_5__0)
+        gs.add_transform("Logicle_10000_0.5_4.5_0", logicle_xform_10000__0_5__4_5__0)
+        gs.add_transform("Hyperlog_10000_1_4.5_0", hyperlog_xform_10000__1__4_5__0)
 
-        gs.add_gate(poly1_gate, ('root',))
+        gs.add_gate(poly1_gate, ("root",))
 
-        dim1 = fk.Dimension('PE', 'MySpill', 'Logicle_10000_0.5_4.5_0', range_min=0.31, range_max=0.69)
-        dim2 = fk.Dimension('PerCP', 'MySpill', 'Logicle_10000_0.5_4.5_0', range_min=0.27, range_max=0.73)
+        dim1 = fk.Dimension(
+            "PE", "MySpill", "Logicle_10000_0.5_4.5_0", range_min=0.31, range_max=0.69
+        )
+        dim2 = fk.Dimension(
+            "PerCP",
+            "MySpill",
+            "Logicle_10000_0.5_4.5_0",
+            range_min=0.27,
+            range_max=0.73,
+        )
         dims1 = [dim1, dim2]
 
-        rect_gate1 = fk.gates.RectangleGate('ScaleRect1', dims1)
-        gs.add_gate(rect_gate1, ('root',))
+        rect_gate1 = fk.gates.RectangleGate("ScaleRect1", dims1)
+        gs.add_gate(rect_gate1, ("root",))
 
-        dim3 = fk.Dimension('FITC', 'MySpill', 'Hyperlog_10000_1_4.5_0', range_min=0.12, range_max=0.43)
+        dim3 = fk.Dimension(
+            "FITC", "MySpill", "Hyperlog_10000_1_4.5_0", range_min=0.12, range_max=0.43
+        )
         dims2 = [dim3]
 
-        rect_gate2 = fk.gates.RectangleGate('ScalePar1', dims2)
-        gs.add_gate(rect_gate2, ('root', 'ScaleRect1'))
+        rect_gate2 = fk.gates.RectangleGate("ScalePar1", dims2)
+        gs.add_gate(rect_gate2, ("root", "ScaleRect1"))
 
-        res_path = 'data/gate_ref/truth/Results_ScalePar1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScalePar1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScalePar1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScalePar1"))
 
     @staticmethod
     def test_add_parent_quadrant_rect_gate():
         gs = fk.GatingStrategy()
-        gs.add_gate(quad1_gate, ('root',))
+        gs.add_gate(quad1_gate, ("root",))
 
-        dim1 = fk.Dimension('FL2-H', 'uncompensated', None, range_min=6, range_max=14.4)
-        dim2 = fk.Dimension('FL4-H', 'uncompensated', None, range_min=7, range_max=16)
+        dim1 = fk.Dimension("FL2-H", "uncompensated", None, range_min=6, range_max=14.4)
+        dim2 = fk.Dimension("FL4-H", "uncompensated", None, range_min=7, range_max=16)
         dims1 = [dim1, dim2]
 
-        rect_gate1 = fk.gates.RectangleGate('ParRectangle1', dims1)
-        gs.add_gate(rect_gate1, ('root', 'Quadrant1', 'FL2P-FL4P'))
+        rect_gate1 = fk.gates.RectangleGate("ParRectangle1", dims1)
+        gs.add_gate(rect_gate1, ("root", "Quadrant1", "FL2P-FL4P"))
 
-        res_path = 'data/gate_ref/truth/Results_ParQuadRect.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ParQuadRect.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         result = gs.gate_sample(data1_sample)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ParRectangle1'))
+        np.testing.assert_array_equal(
+            truth, result.get_gate_membership("ParRectangle1")
+        )
 
     def test_quad_gate_with_parent_gate(self):
         gs = fk.GatingStrategy()
 
-        dim1 = fk.Dimension('SSC-H', compensation_ref='uncompensated', range_min=20, range_max=80)
-        dim2 = fk.Dimension('FL1-H', compensation_ref='uncompensated', range_min=70, range_max=200)
+        dim1 = fk.Dimension(
+            "SSC-H", compensation_ref="uncompensated", range_min=20, range_max=80
+        )
+        dim2 = fk.Dimension(
+            "FL1-H", compensation_ref="uncompensated", range_min=70, range_max=200
+        )
         dims = [dim1, dim2]
 
-        rect_gate = fk.gates.RectangleGate('Rectangle1', dims)
-        gs.add_gate(rect_gate, ('root',))
+        rect_gate = fk.gates.RectangleGate("Rectangle1", dims)
+        gs.add_gate(rect_gate, ("root",))
 
         quad_gate_copy = copy.deepcopy(quad1_gate)
 
-        gs.add_gate(quad_gate_copy, ('root', 'Rectangle1'))
+        gs.add_gate(quad_gate_copy, ("root", "Rectangle1"))
 
         result = gs.gate_sample(data1_sample)
 

--- a/tests/gating_strategy_remove_gates_tests.py
+++ b/tests/gating_strategy_remove_gates_tests.py
@@ -1,11 +1,16 @@
 """
 Test for removing gates from a GatingStrategy
 """
+
 import unittest
 import copy
-from .session_tests import test_samples_8c_full_set_dict
-from .matrix_tests import csv_8c_comp_file_path, detectors_8c
 import flowkit as fk
+
+from tests.test_config import (
+    test_samples_8c_full_set_dict,
+    csv_8c_comp_file_path,
+    detectors_8c,
+)
 
 
 class GatingStrategyRemoveGatesTestCase(unittest.TestCase):
@@ -35,13 +40,13 @@ class GatingStrategyRemoveGatesTestCase(unittest.TestCase):
 
         :return: None
         """
-        sample_id = '101_DEN084Y5_15_E01_008_clean.fcs'
+        sample_id = "101_DEN084Y5_15_E01_008_clean.fcs"
         sample = copy.deepcopy(test_samples_8c_full_set_dict[sample_id])
         comp = fk.Matrix(csv_8c_comp_file_path, detectors_8c)
 
         session = fk.Session()
         session.add_samples(sample)
-        session.add_comp_matrix('spill', comp)
+        session.add_comp_matrix("spill", comp)
 
         # define transforms we'll be using
         # linear transform for our time dimension
@@ -51,45 +56,67 @@ class GatingStrategyRemoveGatesTestCase(unittest.TestCase):
             param_t=262144, param_a=0, param_w=1, param_m=4.418539922
         )
 
-        session.add_transform('time-lin', lin_xform)
-        session.add_transform('scatter-lin', sc_lin_xform)
-        session.add_transform('flr-logicle', flr_xform)
+        session.add_transform("time-lin", lin_xform)
+        session.add_transform("scatter-lin", sc_lin_xform)
+        session.add_transform("flr-logicle", flr_xform)
 
         # time dimension with ranges
-        time_dim = fk.Dimension('Time', transformation_ref='time-lin', range_min=0.1, range_max=0.9)
+        time_dim = fk.Dimension(
+            "Time", transformation_ref="time-lin", range_min=0.1, range_max=0.9
+        )
 
         # scatter dims
-        dim_ssc_w = fk.Dimension('SSC-W', transformation_ref="scatter-lin")
-        dim_ssc_h = fk.Dimension('SSC-H', transformation_ref="scatter-lin")
-        dim_ssc_a = fk.Dimension('SSC-A', transformation_ref="scatter-lin")
-        dim_fsc_w = fk.Dimension('FSC-W', transformation_ref="scatter-lin")
-        dim_fsc_h = fk.Dimension('FSC-H', transformation_ref="scatter-lin")
-        dim_fsc_a = fk.Dimension('FSC-A', transformation_ref="scatter-lin")
+        dim_ssc_w = fk.Dimension("SSC-W", transformation_ref="scatter-lin")
+        dim_ssc_h = fk.Dimension("SSC-H", transformation_ref="scatter-lin")
+        dim_ssc_a = fk.Dimension("SSC-A", transformation_ref="scatter-lin")
+        dim_fsc_w = fk.Dimension("FSC-W", transformation_ref="scatter-lin")
+        dim_fsc_h = fk.Dimension("FSC-H", transformation_ref="scatter-lin")
+        dim_fsc_a = fk.Dimension("FSC-A", transformation_ref="scatter-lin")
 
         # fluoro_dims
-        dim_amine_a = fk.Dimension('Aqua Amine FLR-A', compensation_ref='spill', transformation_ref='flr-logicle')
-        dim_cd3 = fk.Dimension('CD3 APC-H7 FLR-A', compensation_ref='spill', transformation_ref='flr-logicle')
-        dim_cd4 = fk.Dimension('CD4 PE-Cy7 FLR-A', compensation_ref='spill', transformation_ref='flr-logicle')
-        dim_cd8 = fk.Dimension('CD8 PerCP-Cy55 FLR-A', compensation_ref='spill', transformation_ref='flr-logicle')
-        dim_cd107a = fk.Dimension('CD107a PE FLR-A', compensation_ref='spill', transformation_ref='flr-logicle')
+        dim_amine_a = fk.Dimension(
+            "Aqua Amine FLR-A",
+            compensation_ref="spill",
+            transformation_ref="flr-logicle",
+        )
+        dim_cd3 = fk.Dimension(
+            "CD3 APC-H7 FLR-A",
+            compensation_ref="spill",
+            transformation_ref="flr-logicle",
+        )
+        dim_cd4 = fk.Dimension(
+            "CD4 PE-Cy7 FLR-A",
+            compensation_ref="spill",
+            transformation_ref="flr-logicle",
+        )
+        dim_cd8 = fk.Dimension(
+            "CD8 PerCP-Cy55 FLR-A",
+            compensation_ref="spill",
+            transformation_ref="flr-logicle",
+        )
+        dim_cd107a = fk.Dimension(
+            "CD107a PE FLR-A",
+            compensation_ref="spill",
+            transformation_ref="flr-logicle",
+        )
 
         # Start with time gate
-        gate_time = fk.gates.RectangleGate('Time-range', [time_dim])
-        session.add_gate(gate_time, ('root',))
+        gate_time = fk.gates.RectangleGate("Time-range", [time_dim])
+        session.add_gate(gate_time, ("root",))
 
         gate_singlets_poly_vertices = [
             [0.328125, 0.2],
             [0.28, 0.25],
             [0.29, 0.83],
             [0.34765625, 0.3984375],
-            [0.3359375, 0.2]
+            [0.3359375, 0.2],
         ]
         gate_singlets_poly = fk.gates.PolygonGate(
-            'Singlets-poly',
+            "Singlets-poly",
             dimensions=[dim_fsc_w, dim_fsc_h],
-            vertices=gate_singlets_poly_vertices
+            vertices=gate_singlets_poly_vertices,
         )
-        session.add_gate(gate_singlets_poly, ('root', 'Time-range'))
+        session.add_gate(gate_singlets_poly, ("root", "Time-range"))
 
         gate_live_poly_vertices = [
             [0.2629268137285685, 0.0625],
@@ -102,36 +129,46 @@ class GatingStrategyRemoveGatesTestCase(unittest.TestCase):
             [0.29042797365869377, 0.1484375],
         ]
         gate_live_poly = fk.gates.PolygonGate(
-            'Live-poly', dimensions=[dim_amine_a, dim_ssc_a], vertices=gate_live_poly_vertices
+            "Live-poly",
+            dimensions=[dim_amine_a, dim_ssc_a],
+            vertices=gate_live_poly_vertices,
         )
-        session.add_gate(gate_live_poly, ('root', 'Time-range', 'Singlets-poly'))
+        session.add_gate(gate_live_poly, ("root", "Time-range", "Singlets-poly"))
 
         dim_cd3_pos = copy.deepcopy(dim_cd3)
         dim_cd3_pos.min = 0.282
         dim_cd3_pos.max = None
 
-        gate_cd3_pos_range = fk.gates.RectangleGate('CD3-pos-range', dimensions=[dim_cd3_pos])
+        gate_cd3_pos_range = fk.gates.RectangleGate(
+            "CD3-pos-range", dimensions=[dim_cd3_pos]
+        )
         session.add_gate(
-            gate_cd3_pos_range, ('root', 'Time-range', 'Singlets-poly', 'Live-poly')
+            gate_cd3_pos_range, ("root", "Time-range", "Singlets-poly", "Live-poly")
         )
 
-        gate_path_cd3_pos = ('root', 'Time-range', 'Singlets-poly', 'Live-poly', 'CD3-pos-range')
+        gate_path_cd3_pos = (
+            "root",
+            "Time-range",
+            "Singlets-poly",
+            "Live-poly",
+            "CD3-pos-range",
+        )
 
         gate_cd4_pos_vertices = [[0.25, 0.38], [0.65, 0.5], [0.65, 0.8], [0.25, 0.8]]
 
         gate_cd4_pos = fk.gates.PolygonGate(
-            'CD4-pos-poly',
+            "CD4-pos-poly",
             dimensions=[dim_cd3, dim_cd4],
-            vertices=gate_cd4_pos_vertices
+            vertices=gate_cd4_pos_vertices,
         )
         session.add_gate(gate_cd4_pos, gate_path_cd3_pos)
 
         gate_cd8_pos_vertices = [[0.2, 0.38], [0.7, 0.38], [0.7, 0.9], [0.2, 0.9]]
 
         gate_cd8_pos = fk.gates.PolygonGate(
-            'CD8-pos-poly',
+            "CD8-pos-poly",
             dimensions=[dim_cd3, dim_cd8],
-            vertices=gate_cd8_pos_vertices
+            vertices=gate_cd8_pos_vertices,
         )
         session.add_gate(gate_cd8_pos, gate_path_cd3_pos)
 
@@ -140,95 +177,87 @@ class GatingStrategyRemoveGatesTestCase(unittest.TestCase):
 
         gate_cd4_cd8_dbl_pos_refs = [
             {
-                'ref': gate_cd4_pos.gate_name,
-                'path': cd4_pos_gate_paths[0],
-                'complement': False
+                "ref": gate_cd4_pos.gate_name,
+                "path": cd4_pos_gate_paths[0],
+                "complement": False,
             },
             {
-                'ref': gate_cd8_pos.gate_name,
-                'path': cd8_pos_gate_paths[0],
-                'complement': False
-            }
+                "ref": gate_cd8_pos.gate_name,
+                "path": cd8_pos_gate_paths[0],
+                "complement": False,
+            },
         ]
 
         gate_cd4_cd8_dbl_pos = fk.gates.BooleanGate(
-            'CD4-CD8-dbl-pos-bool',
-            'and',
-            gate_cd4_cd8_dbl_pos_refs
+            "CD4-CD8-dbl-pos-bool", "and", gate_cd4_cd8_dbl_pos_refs
         )
         session.add_gate(gate_cd4_cd8_dbl_pos, gate_path_cd3_pos)
 
-        quad1_div1 = fk.QuadrantDivider('div-cd4', dim_cd4.id, 'spill', [0.4], transformation_ref='flr-logicle')
-        quad1_div2 = fk.QuadrantDivider('div-cd8', dim_cd8.id, 'spill', [0.4], transformation_ref='flr-logicle')
+        quad1_div1 = fk.QuadrantDivider(
+            "div-cd4", dim_cd4.id, "spill", [0.4], transformation_ref="flr-logicle"
+        )
+        quad1_div2 = fk.QuadrantDivider(
+            "div-cd8", dim_cd8.id, "spill", [0.4], transformation_ref="flr-logicle"
+        )
         quad1_divs = [quad1_div1, quad1_div2]
 
         quad_1 = fk.gates.Quadrant(
-            quadrant_id='CD4P-CD8P',
-            divider_refs=['div-cd4', 'div-cd8'],
-            divider_ranges=[(0.4, None), (0.4, None)]
+            quadrant_id="CD4P-CD8P",
+            divider_refs=["div-cd4", "div-cd8"],
+            divider_ranges=[(0.4, None), (0.4, None)],
         )
         quad_2 = fk.gates.Quadrant(
-            quadrant_id='CD4N-CD8P',
-            divider_refs=['div-cd4', 'div-cd8'],
-            divider_ranges=[(None, 0.4), (0.4, None)]
+            quadrant_id="CD4N-CD8P",
+            divider_refs=["div-cd4", "div-cd8"],
+            divider_ranges=[(None, 0.4), (0.4, None)],
         )
         quad_3 = fk.gates.Quadrant(
-            quadrant_id='CD4N-CD8N',
-            divider_refs=['div-cd4', 'div-cd8'],
-            divider_ranges=[(None, 0.4), (None, 0.4)]
+            quadrant_id="CD4N-CD8N",
+            divider_refs=["div-cd4", "div-cd8"],
+            divider_ranges=[(None, 0.4), (None, 0.4)],
         )
         quad_4 = fk.gates.Quadrant(
-            quadrant_id='CD4P-CD8N',
-            divider_refs=['div-cd4', 'div-cd8'],
-            divider_ranges=[(0.4, None), (None, 0.4)]
+            quadrant_id="CD4P-CD8N",
+            divider_refs=["div-cd4", "div-cd8"],
+            divider_ranges=[(0.4, None), (None, 0.4)],
         )
         quadrants_q1 = [quad_1, quad_2, quad_3, quad_4]
 
-        quad1_gate = fk.gates.QuadrantGate('Q-CD4-CD8', quad1_divs, quadrants_q1)
+        quad1_gate = fk.gates.QuadrantGate("Q-CD4-CD8", quad1_divs, quadrants_q1)
         session.add_gate(quad1_gate, gate_path_cd3_pos)
 
         # the next bool gate will be CD4+ OR CD8+ from the quadrants
-        cd4_pos_q_gate_paths = session.find_matching_gate_paths('CD4P-CD8N')
-        cd8_pos_q_gate_paths = session.find_matching_gate_paths('CD4N-CD8P')
+        cd4_pos_q_gate_paths = session.find_matching_gate_paths("CD4P-CD8N")
+        cd8_pos_q_gate_paths = session.find_matching_gate_paths("CD4N-CD8P")
 
         gate_cd4_or_cd8_pos_refs = [
-            {
-                'ref': 'CD4P-CD8N',
-                'path': cd4_pos_q_gate_paths[0],
-                'complement': False
-            },
-            {
-                'ref': 'CD4N-CD8P',
-                'path': cd8_pos_q_gate_paths[0],
-                'complement': False
-            }
+            {"ref": "CD4P-CD8N", "path": cd4_pos_q_gate_paths[0], "complement": False},
+            {"ref": "CD4N-CD8P", "path": cd8_pos_q_gate_paths[0], "complement": False},
         ]
 
         gate_cd4_or_cd8_pos = fk.gates.BooleanGate(
-            'CD4-or-CD8-pos-bool',
-            'or',
-            gate_cd4_or_cd8_pos_refs
+            "CD4-or-CD8-pos-bool", "or", gate_cd4_or_cd8_pos_refs
         )
         session.add_gate(gate_cd4_or_cd8_pos, gate_path_cd3_pos)
-        gate_path_cd4_or_cd8_pos = tuple(list(gate_path_cd3_pos) + [gate_cd4_or_cd8_pos.gate_name])
+        gate_path_cd4_or_cd8_pos = tuple(
+            list(gate_path_cd3_pos) + [gate_cd4_or_cd8_pos.gate_name]
+        )
 
         dim_cd107a_pos = copy.deepcopy(dim_cd107a)
         dim_cd107a_pos.min = 0.4
         dim_cd107a_pos.max = None
 
         dim_cd107a_pos_range = fk.gates.RectangleGate(
-            'CD107a-pos-range',
-            dimensions=[dim_cd107a_pos]
+            "CD107a-pos-range", dimensions=[dim_cd107a_pos]
         )
         # this goes under the CD4N-CD8P Quadrant
         cd8_pos_q_gate_path_full = list(cd8_pos_q_gate_paths[0])
-        cd8_pos_q_gate_path_full.append('CD4N-CD8P')
+        cd8_pos_q_gate_path_full.append("CD4N-CD8P")
         cd8_pos_q_gate_path_full = tuple(cd8_pos_q_gate_path_full)
         session.add_gate(dim_cd107a_pos_range, cd8_pos_q_gate_path_full)
 
         dim_cd107a_pos_range2 = fk.gates.RectangleGate(
-            'CD107a-pos-range',
-            dimensions=[dim_cd107a_pos]
+            "CD107a-pos-range", dimensions=[dim_cd107a_pos]
         )
         session.add_gate(dim_cd107a_pos_range2, gate_path_cd4_or_cd8_pos)
 
@@ -236,23 +265,32 @@ class GatingStrategyRemoveGatesTestCase(unittest.TestCase):
 
     def test_remove_quadrant_fails(self):
         gs = copy.deepcopy(self.gating_strategy)
-        gate_name_to_remove = 'CD4P-CD8N'
+        gate_name_to_remove = "CD4P-CD8N"
 
-        self.assertRaises(fk.exceptions.QuadrantReferenceError, gs.remove_gate, gate_name_to_remove)
+        self.assertRaises(
+            fk.exceptions.QuadrantReferenceError, gs.remove_gate, gate_name_to_remove
+        )
 
     def test_remove_gate_with_bool_dep_fails(self):
         gs = copy.deepcopy(self.gating_strategy)
-        gate_name_to_remove = 'Q-CD4-CD8'
+        gate_name_to_remove = "Q-CD4-CD8"
 
-        self.assertRaises(fk.exceptions.GateTreeError, gs.remove_gate, gate_name_to_remove, keep_children=True)
+        self.assertRaises(
+            fk.exceptions.GateTreeError,
+            gs.remove_gate,
+            gate_name_to_remove,
+            keep_children=True,
+        )
 
     def test_remove_bool_dep(self):
         gs = copy.deepcopy(self.gating_strategy)
-        gate_name_to_remove = 'CD4-or-CD8-pos-bool'
+        gate_name_to_remove = "CD4-or-CD8-pos-bool"
 
         gs.remove_gate(gate_name_to_remove)
 
-        self.assertRaises(fk.exceptions.GateReferenceError, gs.get_gate, gate_name_to_remove)
+        self.assertRaises(
+            fk.exceptions.GateReferenceError, gs.get_gate, gate_name_to_remove
+        )
 
     def test_remove_gate_keep_children(self):
         # reminder of gate tree relevant to test:
@@ -262,16 +300,13 @@ class GatingStrategyRemoveGatesTestCase(unittest.TestCase):
         #         ╰── Live-poly
         #             ╰── CD3-pos-range
 
-        gate_name_to_remove = 'Live-poly'
+        gate_name_to_remove = "Live-poly"
 
-        parent_gate_name = 'Singlets-poly'
+        parent_gate_name = "Singlets-poly"
 
         # new child gate IDs will omit 'Live-poly'
         ground_truth_new_child_gate_ids = [
-            (
-                'CD3-pos-range',
-                ('root', 'Time-range', 'Singlets-poly')
-            )
+            ("CD3-pos-range", ("root", "Time-range", "Singlets-poly"))
         ]
 
         gs = copy.deepcopy(self.gating_strategy)

--- a/tests/gating_strategy_tests.py
+++ b/tests/gating_strategy_tests.py
@@ -4,49 +4,9 @@ Tests for GatingStrategy Class
 import unittest
 import numpy as np
 import flowkit as fk
-from .session_tests import test_samples_8c_full_set_dict
+from tests.test_config import data1_sample, poly1_vertices, poly1_dims1, poly1_gate, hyperlog_xform_10000__1__4_5__0, logicle_xform_10000__0_5__4_5__0, spill01_fluoros, spill01_detectors, spill01_data, sample_with_spill, comp_matrix_01
 
 
-data1_fcs_path = 'data/gate_ref/data1.fcs'
-data1_sample = fk.Sample(data1_fcs_path)
-
-poly1_vertices = [
-    [5, 5],
-    [500, 5],
-    [500, 500]
-]
-poly1_dim1 = fk.Dimension('FL2-H', compensation_ref='FCS')
-poly1_dim2 = fk.Dimension('FL3-H', compensation_ref='FCS')
-poly1_dims1 = [poly1_dim1, poly1_dim2]
-poly1_gate = fk.gates.PolygonGate('Polygon1', poly1_dims1, poly1_vertices)
-
-hyperlog_xform_10000__1__4_5__0 = fk.transforms.HyperlogTransform(
-    param_t=10000,
-    param_w=1,
-    param_m=4.5,
-    param_a=0
-)
-
-logicle_xform_10000__0_5__4_5__0 = fk.transforms.LogicleTransform(
-    param_t=10000,
-    param_w=0.5,
-    param_m=4.5,
-    param_a=0
-)
-
-spill01_fluoros = ['FITC', 'PE', 'PerCP']
-spill01_detectors = ['FL1-H', 'FL2-H', 'FL3-H']
-spill01_data = np.array(
-    [
-        [1, 0.02, 0.06],
-        [0.11, 1, 0.07],
-        [0.09, 0.01, 1]
-    ]
-)
-comp_matrix_01 = fk.Matrix(spill01_data, spill01_detectors, spill01_fluoros)
-
-sample_id_with_spill = '101_DEN084Y5_15_E01_008_clean.fcs'
-sample_with_spill = test_samples_8c_full_set_dict[sample_id_with_spill]
 
 
 class GatingStrategyTestCase(unittest.TestCase):

--- a/tests/gatingml_tests.py
+++ b/tests/gatingml_tests.py
@@ -6,8 +6,7 @@ import pandas as pd
 
 from flowkit import Sample, GatingStrategy, Session, parse_gating_xml
 
-data1_fcs_path = 'data/gate_ref/data1.fcs'
-data1_sample = Sample(data1_fcs_path)
+from tests.test_config import data1_sample
 
 
 class GatingMLTestCase(unittest.TestCase):

--- a/tests/matrix_tests.py
+++ b/tests/matrix_tests.py
@@ -1,6 +1,7 @@
 """
 Matrix class tests
 """
+
 import copy
 import unittest
 import numpy as np
@@ -8,94 +9,38 @@ import pandas as pd
 import warnings
 import flowkit as fk
 
-fcs_spill = '13,B515-A,R780-A,R710-A,R660-A,V800-A,V655-A,V585-A,V450-A,G780-A,G710-A,G660-A,G610-A,G560-A,'\
-    '1,0,0,0.00008841570561316703,0.0002494559842740046,0.0006451591561972469,0.007198401782797728,0,0,'\
-    '0.00013132619816952714,0.0000665251222573374,0.0005815839652764308,0.0025201730479353047,0,1,'\
-    '0.07118758880093266,0.14844804153215532,0.3389031912802132,0.00971660311243448,0,0,0.3013801753249257,'\
-    '0.007477611134717788,0.0123543122066652,0,0,0,0.33140488468849205,1,0.0619647566095391,0.12097867005182314,'\
-    '0.004052554840959644,0,0,0.1091165124197372,0.10031383324016652,0.005831773047424356,0,0,0,'\
-    '0.08862108746390694,0.38942413967608824,1,0.029758767352535288,0.06555281586224636,0,0,0.03129393154653089,'\
-    '0.039305936245674286,0.09137451237674046,0.00039591122341817164,0.000056659766405160846,0,'\
-    '0.13661791418865094,0.010757316236957385,0,1,0.00015647113960278087,0,0,0.48323487842103036,'\
-    '0.01485813345103798,0,0,0,0,0.00012365104122837034,0.019462610460087203,0.2182062762553545,'\
-    '0.004953221988365214,1,0.003582785726251024,0,0.0013106968243292993,0.029645575685206288,0.4089015923558522,'\
-    '0.006505826616588717,0.00011917703878954761,0,0,0,0,0.001055595075733903,0.002287122431059274,1,0,'\
-    '0.0003885172922042414,0.0001942589956485108,0,0.06255131165904257,0.13248446095817049,0,0,0,0,0,'\
-    '0.008117870042687002,0.17006643956891296,1,0,0,0,0,0,0.003122390646560834,0.008525685683831916,'\
-    '0.001024237027323255,0.0011626412849951272,0.12540105131097395,0.018142202256893485,0.19364562239714117,'\
-    '0,1,0.06689784643460173,0.16145640353506588,0.2868231743828476,1.2380368696528024,0.002015498041918758,'\
-    '0.06964529385206036,0.19471548842271394,0.0010077719457714136,0.15161117217667686,0.0012703511702660231,'\
-    '0.007133491446011225,0,1.1500323358669722,1,0.016076827046672983,0.014674146885307975,0.055351746085494,'\
-    '0.001685226072130514,0.05433993817875603,0.27785224557295884,0.34300826602551504,0.06175281041168121,'\
-    '0.07752283973796613,0.0042628794531131406,0,0.49748791920091034,0.7439226300384197,1,0.010329232815907474,'\
-    '0.03763461149817695,0,0.008713148000954844,0.04821275078920058,0.07319044343609345,0.1505631929508567,'\
-    '0.3862934410767249,0.10189631814602482,0,0.3702770755789083,0.6134900271606913,1.2180240147472128,1,'\
-    '0.06521131251063482,0.0016842378874079343,0,0,0.00009533732312150527,0.0034630076700367675,'\
-    '0.01571183587491517,0.17412189188164517,0,0.023802192010810994,0.049474451704249904,0.13251071256825273,'\
-    '0.23921555785727822,1'
-
-fcs_spill_header = [
-    'B515-A', 'R780-A', 'R710-A', 'R660-A',
-    'V800-A', 'V655-A', 'V585-A', 'V450-A',
-    'G780-A', 'G710-A', 'G660-A', 'G610-A',
-    'G560-A'
-]
-
-csv_8c_comp_file_path = 'data/8_color_data_set/den_comp.csv'
-detectors_8c = [
-    'TNFa FITC FLR-A',
-    'CD8 PerCP-Cy55 FLR-A',
-    'IL2 BV421 FLR-A',
-    'Aqua Amine FLR-A',
-    'IFNg APC FLR-A',
-    'CD3 APC-H7 FLR-A',
-    'CD107a PE FLR-A',
-    'CD4 PE-Cy7 FLR-A'
-]
-fluorochromes_8c = [
-    'TNFa',
-    'CD8',
-    'IL2',
-    'Aqua Amine',
-    'IFNg',
-    'CD3',
-    'CD107a',
-    'CD4'
-]
-
-csv_8c_comp_null_channel_file_path = 'data/8_color_data_set/den_comp_null_channel.csv'
+from tests.test_config import (
+    fcs_spill,
+    fcs_spill_header,
+    csv_8c_comp_file_path,
+    detectors_8c,
+    fluorochromes_8c,
+    csv_8c_comp_null_channel_file_path,
+)
 
 
 class MatrixTestCase(unittest.TestCase):
     """Tests related to compensation matrices and the Matrix class"""
+
     def test_matrix_from_fcs_spill(self):
         comp_mat = fk.Matrix(fcs_spill, fcs_spill_header)
 
         self.assertIsInstance(comp_mat, fk.Matrix)
 
     def test_parse_csv_file(self):
-        comp_mat = fk.Matrix(
-            csv_8c_comp_file_path,
-            detectors_8c
-        )
+        comp_mat = fk.Matrix(csv_8c_comp_file_path, detectors_8c)
 
         self.assertIsInstance(comp_mat, fk.Matrix)
 
     def test_matrix_equals(self):
-        comp_mat = fk.Matrix(
-            csv_8c_comp_file_path,
-            detectors_8c
-        )
+        comp_mat = fk.Matrix(csv_8c_comp_file_path, detectors_8c)
 
         comp_mat2 = copy.deepcopy(comp_mat)
 
         self.assertEqual(comp_mat, comp_mat2)
 
     def test_matrix_equals_fails(self):
-        comp_mat = fk.Matrix(
-            csv_8c_comp_file_path,
-            detectors_8c
-        )
+        comp_mat = fk.Matrix(csv_8c_comp_file_path, detectors_8c)
 
         # copy & modify matrix array
         comp_mat2 = copy.deepcopy(comp_mat)
@@ -105,9 +50,7 @@ class MatrixTestCase(unittest.TestCase):
 
     def test_matrix_as_dataframe(self):
         comp_mat = fk.Matrix(
-            csv_8c_comp_file_path,
-            detectors_8c,
-            fluorochromes=fluorochromes_8c
+            csv_8c_comp_file_path, detectors_8c, fluorochromes=fluorochromes_8c
         )
 
         # test with detectors as labels
@@ -120,7 +63,9 @@ class MatrixTestCase(unittest.TestCase):
         self.assertIsInstance(comp_df_fluorochromes, pd.DataFrame)
 
     def test_reserved_matrix_id_uncompensated(self):
-        self.assertRaises(ValueError, fk.Matrix, 'uncompensated', fcs_spill, fcs_spill_header)
+        self.assertRaises(
+            ValueError, fk.Matrix, "uncompensated", fcs_spill, fcs_spill_header
+        )
 
     @staticmethod
     def test_matrix_inverse():
@@ -128,30 +73,32 @@ class MatrixTestCase(unittest.TestCase):
         comp_file_path = "data/comp_complete_example.csv"
 
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+            warnings.simplefilter("ignore")
             sample = fk.Sample(
                 fcs_path_or_data=fcs_file_path,
                 compensation=comp_file_path,
-                ignore_offset_error=True  # sample has off by 1 data offset
+                ignore_offset_error=True,  # sample has off by 1 data offset
             )
         matrix = sample.compensation
 
-        data_raw = sample.get_events(source='raw')
+        data_raw = sample.get_events(source="raw")
         inv_data = matrix.inverse(sample)
 
         np.testing.assert_almost_equal(inv_data, data_raw, 10)
 
     def test_null_channels(self):
         # pretend FITC is a null channel
-        null_channels = ['TNFa FITC FLR-A']
+        null_channels = ["TNFa FITC FLR-A"]
 
         comp_mat = fk.Matrix(
             csv_8c_comp_null_channel_file_path,
             detectors_8c,
-            null_channels=null_channels
+            null_channels=null_channels,
         )
 
-        fcs_file_path = "data/8_color_data_set/fcs_files/101_DEN084Y5_15_E01_008_clean.fcs"
+        fcs_file_path = (
+            "data/8_color_data_set/fcs_files/101_DEN084Y5_15_E01_008_clean.fcs"
+        )
 
         # test with a sample not using null channels and one using null channels
         sample1 = fk.Sample(fcs_file_path, null_channel_list=None)

--- a/tests/plot_tests.py
+++ b/tests/plot_tests.py
@@ -7,9 +7,9 @@ from bokeh.plotting import figure as bk_Figure
 from bokeh.layouts import GridPlot as bk_GridPlot
 import flowkit as fk
 
-fcs_path = 'data/gate_ref/data1.fcs'
-gml_path = 'data/gate_ref/gml/gml_all_gates.xml'
-test_sample = fk.Sample(fcs_path, subsample=2000)
+from tests.test_config import test_sample, gml_path
+
+
 test_gating_strategy = fk.parse_gating_xml(gml_path)
 
 

--- a/tests/sample_export_tests.py
+++ b/tests/sample_export_tests.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 import pandas as pd
 import unittest
-from .sample_tests import test_comp_sample, data1_fcs_path
+from tests.test_config import test_comp_sample, data1_fcs_path
 
 from flowkit import Sample
 

--- a/tests/session_export_tests.py
+++ b/tests/session_export_tests.py
@@ -5,7 +5,7 @@ import copy
 import unittest
 from io import BytesIO
 from flowkit import Session, Workspace, gates
-from .session_tests import test_samples_8c_full_set
+from tests.test_config import test_samples_8c_full_set
 
 
 class SessionExportTestCase(unittest.TestCase):

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -1,6 +1,7 @@
 """
 Session Tests
 """
+
 import copy
 import unittest
 import numpy as np
@@ -8,24 +9,29 @@ import pandas as pd
 import warnings
 
 from flowkit import (
-    Session, Sample, Matrix, Dimension, gates, transforms, load_samples, generate_transforms
+    Session,
+    Sample,
+    Matrix,
+    Dimension,
+    gates,
+    transforms,
+    load_samples,
+    generate_transforms,
 )
-from .gating_strategy_prog_gate_tests import (
-    data1_sample, poly1_gate, poly1_vertices, comp_matrix_01, asinh_xform_10000_4_1
+from tests.test_config import (
+    fcs_file_paths,
+    test_samples_base_set,
+    data1_sample,
+    poly1_gate,
+    poly1_vertices,
+    comp_matrix_01,
+    asinh_xform_10000_4_1,
 )
-
-fcs_file_paths = [
-    "data/100715.fcs",
-    "data/109567.fcs",
-    "data/113548.fcs"
-]
-test_samples_base_set = load_samples(fcs_file_paths)
-test_samples_8c_full_set = load_samples("data/8_color_data_set/fcs_files")
-test_samples_8c_full_set_dict = {s.id: s for s in test_samples_8c_full_set}
 
 
 class SessionTestCase(unittest.TestCase):
     """Tests for Session class"""
+
     def test_create_session_raises(self):
         # verify non-valid args raise ValueError
         self.assertRaises(ValueError, Session, {})
@@ -34,7 +40,7 @@ class SessionTestCase(unittest.TestCase):
         fks = Session(fcs_samples=fcs_file_paths)
 
         self.assertEqual(len(fks.sample_lut.keys()), 3)
-        self.assertIsInstance(fks.get_sample('100715.fcs'), Sample)
+        self.assertIsInstance(fks.get_sample("100715.fcs"), Sample)
 
         sample_ids = ["100715.fcs", "109567.fcs", "113548.fcs"]
         self.assertListEqual(fks.get_sample_ids(), sample_ids)
@@ -44,7 +50,7 @@ class SessionTestCase(unittest.TestCase):
         fks = Session(fcs_samples=samples)
 
         self.assertEqual(len(fks.sample_lut.keys()), 3)
-        self.assertIsInstance(fks.get_sample('100715.fcs'), Sample)
+        self.assertIsInstance(fks.get_sample("100715.fcs"), Sample)
 
     def test_add_samples_sample_already_exists(self):
         samples = copy.deepcopy(test_samples_base_set)
@@ -55,7 +61,7 @@ class SessionTestCase(unittest.TestCase):
         # add sample that was already added above
         # ignore warning about already existing sample
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+            warnings.simplefilter("ignore")
             fks.add_samples(samples[0])
 
         # verify sample count didn't change
@@ -63,18 +69,18 @@ class SessionTestCase(unittest.TestCase):
 
     def test_get_comp_matrix(self):
         fks = Session()
-        fks.add_comp_matrix('MySpill', comp_matrix_01)
-        comp_mat = fks.get_comp_matrix('MySpill')
+        fks.add_comp_matrix("MySpill", comp_matrix_01)
+        comp_mat = fks.get_comp_matrix("MySpill")
 
         self.assertIsInstance(comp_mat, Matrix)
 
     def test_get_comp_matrices(self):
         fks = Session()
-        fks.add_comp_matrix('MySpill', comp_matrix_01)
+        fks.add_comp_matrix("MySpill", comp_matrix_01)
         comp_matrix_02 = copy.deepcopy(comp_matrix_01)
-        fks.add_comp_matrix('MySpill2', comp_matrix_02)
+        fks.add_comp_matrix("MySpill2", comp_matrix_02)
 
-        matrix_lut = {'MySpill': comp_matrix_01, 'MySpill2': comp_matrix_02}
+        matrix_lut = {"MySpill": comp_matrix_01, "MySpill2": comp_matrix_02}
 
         session_matrix_lut = fks.get_comp_matrices()
 
@@ -82,8 +88,8 @@ class SessionTestCase(unittest.TestCase):
 
     def test_get_transform(self):
         fks = Session()
-        fks.add_transform('AsinH_10000_4_1', asinh_xform_10000_4_1)
-        xform = fks.get_transform('AsinH_10000_4_1')
+        fks.add_transform("AsinH_10000_4_1", asinh_xform_10000_4_1)
+        xform = fks.get_transform("AsinH_10000_4_1")
 
         self.assertIsInstance(xform, transforms.AsinhTransform)
 
@@ -103,69 +109,71 @@ class SessionTestCase(unittest.TestCase):
     def test_add_poly1_gate():
         fks = Session()
         fks.add_samples(data1_sample)
-        fks.add_gate(poly1_gate, ('root',))
+        fks.add_gate(poly1_gate, ("root",))
         fks.analyze_samples()
         result = fks.get_gating_results(data1_sample.id)
 
-        res_path = 'data/gate_ref/truth/Results_Polygon1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Polygon1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Polygon1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Polygon1"))
 
     def test_get_gate_from_template(self):
         fks = Session()
         fks.add_samples(data1_sample)
-        fks.add_gate(poly1_gate, ('root',))
+        fks.add_gate(poly1_gate, ("root",))
 
-        template_gate = fks.get_gate('Polygon1')
+        template_gate = fks.get_gate("Polygon1")
 
-        self.assertEqual(template_gate.gate_name, 'Polygon1')
+        self.assertEqual(template_gate.gate_name, "Polygon1")
 
     @staticmethod
     def test_add_matrix_poly4_gate():
         fks = Session()
         fks.add_samples(data1_sample)
 
-        fks.add_comp_matrix('MySpill', comp_matrix_01)
+        fks.add_comp_matrix("MySpill", comp_matrix_01)
 
-        dim1 = Dimension('PE', compensation_ref='MySpill')
-        dim2 = Dimension('PerCP', compensation_ref='MySpill')
+        dim1 = Dimension("PE", compensation_ref="MySpill")
+        dim2 = Dimension("PerCP", compensation_ref="MySpill")
         dims = [dim1, dim2]
 
-        poly_gate = gates.PolygonGate('Polygon4', dims, poly1_vertices)
-        fks.add_gate(poly_gate, ('root',))
+        poly_gate = gates.PolygonGate("Polygon4", dims, poly1_vertices)
+        fks.add_gate(poly_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_Polygon4.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_Polygon4.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         fks.analyze_samples()
         result = fks.get_gating_results(data1_sample.id)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('Polygon4'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("Polygon4"))
 
     @staticmethod
     def test_add_transform_asinh_range1_gate():
         fks = Session()
         fks.add_samples(data1_sample)
-        fks.add_transform('AsinH_10000_4_1', asinh_xform_10000_4_1)
+        fks.add_transform("AsinH_10000_4_1", asinh_xform_10000_4_1)
 
-        dim1 = Dimension('FL1-H', 'uncompensated', 'AsinH_10000_4_1', range_min=0.37, range_max=0.63)
+        dim1 = Dimension(
+            "FL1-H", "uncompensated", "AsinH_10000_4_1", range_min=0.37, range_max=0.63
+        )
         dims = [dim1]
 
-        rect_gate = gates.RectangleGate('ScaleRange1', dims)
-        fks.add_gate(rect_gate, ('root',))
+        rect_gate = gates.RectangleGate("ScaleRange1", dims)
+        fks.add_gate(rect_gate, ("root",))
 
-        res_path = 'data/gate_ref/truth/Results_ScaleRange1.txt'
-        truth = pd.read_csv(res_path, header=None, dtype='bool').squeeze().values
+        res_path = "data/gate_ref/truth/Results_ScaleRange1.txt"
+        truth = pd.read_csv(res_path, header=None, dtype="bool").squeeze().values
 
         fks.analyze_samples()
         result = fks.get_gating_results(data1_sample.id)
 
-        np.testing.assert_array_equal(truth, result.get_gate_membership('ScaleRange1'))
+        np.testing.assert_array_equal(truth, result.get_gate_membership("ScaleRange1"))
 
     def test_get_gate_hierarchy(self):
-        gml_path = 'data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml'
-        fcs_path = 'data/gate_ref/data1.fcs'
+        gml_path = "data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml"
+        fcs_path = "data/gate_ref/data1.fcs"
 
         session = Session(gating_strategy=gml_path, fcs_samples=fcs_path)
 
@@ -180,37 +188,35 @@ class SessionTestCase(unittest.TestCase):
         self.assertEqual(hierarchy_ascii, hierarchy_truth)
 
     def test_get_sample_gates(self):
-        gml_path = 'data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml'
-        fcs_path = 'data/gate_ref/data1.fcs'
-        sample_id = 'B07'
+        gml_path = "data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml"
+        fcs_path = "data/gate_ref/data1.fcs"
+        sample_id = "B07"
 
         session = Session(gating_strategy=gml_path, fcs_samples=fcs_path)
 
         sample_gates = session.get_sample_gates(sample_id)
         sample_gate_names = {g.gate_name for g in sample_gates}
 
-        truth_gate_names = {
-            'Range1', 'Polygon1', 'ParAnd2', 'Ellipse1'
-        }
+        truth_gate_names = {"Range1", "Polygon1", "ParAnd2", "Ellipse1"}
 
         self.assertSetEqual(sample_gate_names, truth_gate_names)
 
     def test_get_child_gate_ids(self):
-        gml_path = 'data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml'
-        fcs_path = 'data/gate_ref/data1.fcs'
-        parent_gate_id = 'Polygon1'
+        gml_path = "data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml"
+        fcs_path = "data/gate_ref/data1.fcs"
+        parent_gate_id = "Polygon1"
 
         session = Session(gating_strategy=gml_path, fcs_samples=fcs_path)
 
         child_gate_ids = session.get_child_gate_ids(parent_gate_id)
 
-        truth_gate_ids = [('ParAnd2', ('root', 'Polygon1'))]
+        truth_gate_ids = [("ParAnd2", ("root", "Polygon1"))]
 
         self.assertListEqual(child_gate_ids, truth_gate_ids)
 
     def test_get_analysis_report(self):
-        gml_path = 'data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml'
-        fcs_path = 'data/gate_ref/data1.fcs'
+        gml_path = "data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml"
+        fcs_path = "data/gate_ref/data1.fcs"
 
         session = Session(gating_strategy=gml_path, fcs_samples=fcs_path)
         session.analyze_samples()
@@ -221,9 +227,9 @@ class SessionTestCase(unittest.TestCase):
         self.assertEqual(session_report.shape, (4, 10))
 
     def test_get_gating_results_raises(self):
-        gml_path = 'data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml'
-        fcs_path = 'data/gate_ref/data1.fcs'
-        sample_id = 'B07'
+        gml_path = "data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml"
+        fcs_path = "data/gate_ref/data1.fcs"
+        sample_id = "B07"
 
         session = Session(gating_strategy=gml_path, fcs_samples=fcs_path)
 
@@ -231,14 +237,14 @@ class SessionTestCase(unittest.TestCase):
         self.assertRaises(KeyError, session.get_gating_results, sample_id)
 
     def test_get_gate_events(self):
-        gml_path = 'data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml'
-        fcs_path = 'data/gate_ref/data1.fcs'
-        sample_id = 'B07'
+        gml_path = "data/gate_ref/gml/gml_parent_poly1_boolean_and2_gate.xml"
+        fcs_path = "data/gate_ref/data1.fcs"
+        sample_id = "B07"
 
         session = Session(gating_strategy=gml_path, fcs_samples=fcs_path)
         session.analyze_samples()
 
-        gate_events = session.get_gate_events(sample_id, gate_name='ParAnd2')
+        gate_events = session.get_gate_events(sample_id, gate_name="ParAnd2")
 
         self.assertIsInstance(gate_events, pd.DataFrame)
         self.assertEqual(len(gate_events), 12)

--- a/tests/string_repr_tests.py
+++ b/tests/string_repr_tests.py
@@ -1,41 +1,47 @@
 """
 Unit tests for string representations
 """
+
 import unittest
 import flowkit as fk
-from . import gating_strategy_prog_gate_tests as prog_test_data
 
-data1_fcs_path = 'data/gate_ref/data1.fcs'
-data1_sample = fk.Sample(data1_fcs_path)
+from tests.test_config import (
+    data1_sample,
+    comp_matrix_01,
+    poly1_gate,
+    range1_gate,
+    ellipse1_gate,
+    quad1_gate,
+    logicle_xform_10000__0_5__4_5__0,
+    hyperlog_xform_10000__1__4_5__0,
+)
 
 
 class StringReprTestCase(unittest.TestCase):
     """Tests related to string representations of FlowKit classes"""
+
     def test_dim_repr(self):
-        poly1_dim1 = fk.Dimension('FL2-H', compensation_ref='FCS')
+        poly1_dim1 = fk.Dimension("FL2-H", compensation_ref="FCS")
         dim_string = "Dimension(id: FL2-H)"
 
         self.assertEqual(repr(poly1_dim1), dim_string)
 
     def test_ratio_dim_repr(self):
         dim_rat1 = fk.RatioDimension(
-            'FL2Rat1',
-            compensation_ref='uncompensated',
-            range_min=3,
-            range_max=16.4
+            "FL2Rat1", compensation_ref="uncompensated", range_min=3, range_max=16.4
         )
         dim_string = "RatioDimension(ratio_reference: FL2Rat1)"
 
         self.assertEqual(repr(dim_rat1), dim_string)
 
     def test_quad_div_repr(self):
-        quad1_div1 = fk.QuadrantDivider('FL2', 'FL2-H', 'FCS', [12.14748])
+        quad1_div1 = fk.QuadrantDivider("FL2", "FL2-H", "FCS", [12.14748])
         quad_div_string = "QuadrantDivider(id: FL2, dim_ref: FL2-H)"
 
         self.assertEqual(repr(quad1_div1), quad_div_string)
 
     def test_matrix_repr(self):
-        comp_mat = prog_test_data.comp_matrix_01
+        comp_mat = comp_matrix_01
         comp_mat_string = "Matrix(dims: 3)"
 
         self.assertEqual(repr(comp_mat), comp_mat_string)
@@ -53,20 +59,26 @@ class StringReprTestCase(unittest.TestCase):
         self.assertEqual(repr(xform), xform_string)
 
     def test_ratio_transform_repr(self):
-        ratio_dims = ['FL1-H', 'FL2-H']
-        xform = fk.transforms.RatioTransform(ratio_dims, param_a=1.0, param_b=0.0, param_c=0.0)
+        ratio_dims = ["FL1-H", "FL2-H"]
+        xform = fk.transforms.RatioTransform(
+            ratio_dims, param_a=1.0, param_b=0.0, param_c=0.0
+        )
         xform_string = "RatioTransform(FL1-H / FL2-H, a: 1.0, b: 0.0, c: 0.0)"
 
         self.assertEqual(repr(xform), xform_string)
 
     def test_hyperlog_transform_repr(self):
-        xform = fk.transforms.HyperlogTransform(param_t=10000.0, param_w=0.5, param_m=4.5, param_a=0.0)
+        xform = fk.transforms.HyperlogTransform(
+            param_t=10000.0, param_w=0.5, param_m=4.5, param_a=0.0
+        )
         xform_string = "HyperlogTransform(t: 10000.0, w: 0.5, m: 4.5, a: 0.0)"
 
         self.assertEqual(repr(xform), xform_string)
 
     def test_logicle_transform_repr(self):
-        xform = fk.transforms.LogicleTransform(param_t=10000.0, param_w=0.5, param_m=4.5, param_a=0.0)
+        xform = fk.transforms.LogicleTransform(
+            param_t=10000.0, param_w=0.5, param_m=4.5, param_a=0.0
+        )
         xform_string = "LogicleTransform(t: 10000.0, w: 0.5, m: 4.5, a: 0.0)"
 
         self.assertEqual(repr(xform), xform_string)
@@ -91,28 +103,28 @@ class StringReprTestCase(unittest.TestCase):
         self.assertEqual(repr(sample), sample_string)
 
     def test_rect_gate_repr(self):
-        gate = prog_test_data.range1_gate
+        gate = range1_gate
 
         repr_string = "RectangleGate(Range1, dims: 1)"
 
         self.assertEqual(repr(gate), repr_string)
 
     def test_poly_gate_repr(self):
-        gate = prog_test_data.poly1_gate
+        gate = poly1_gate
 
         repr_string = "PolygonGate(Polygon1, vertices: 3)"
 
         self.assertEqual(repr(gate), repr_string)
 
     def test_ellipsoid_gate_repr(self):
-        gate = prog_test_data.ellipse1_gate
+        gate = ellipse1_gate
 
         repr_string = "EllipsoidGate(Ellipse1, coords: [12.99701, 16.22941])"
 
         self.assertEqual(repr(gate), repr_string)
 
     def test_quad_gate_repr(self):
-        gate = prog_test_data.quad1_gate
+        gate = quad1_gate
 
         repr_string = "QuadrantGate(Quadrant1, quadrants: 4)"
 
@@ -120,19 +132,11 @@ class StringReprTestCase(unittest.TestCase):
 
     def test_bool_gate_repr(self):
         gate_refs = [
-            {
-                'ref': 'Polygon1',
-                'path': ('root',),
-                'complement': False
-            },
-            {
-                'ref': 'Range2',
-                'path': ('root',),
-                'complement': False
-            }
+            {"ref": "Polygon1", "path": ("root",), "complement": False},
+            {"ref": "Range2", "path": ("root",), "complement": False},
         ]
 
-        gate = fk.gates.BooleanGate('And1', 'and', gate_refs)
+        gate = fk.gates.BooleanGate("And1", "and", gate_refs)
 
         repr_string = "BooleanGate(And1, type: and)"
 
@@ -141,25 +145,35 @@ class StringReprTestCase(unittest.TestCase):
     def test_gating_strategy_repr(self):
         gs = fk.GatingStrategy()
 
-        gs.add_comp_matrix('MySpill', prog_test_data.comp_matrix_01)
+        gs.add_comp_matrix("MySpill", comp_matrix_01)
 
-        gs.add_transform('Logicle_10000_0.5_4.5_0', prog_test_data.logicle_xform_10000_0_5__4_5__0)
-        gs.add_transform('Hyperlog_10000_1_4.5_0', prog_test_data.hyperlog_xform_10000__1__4_5__0)
+        gs.add_transform("Logicle_10000_0.5_4.5_0", logicle_xform_10000__0_5__4_5__0)
+        gs.add_transform("Hyperlog_10000_1_4.5_0", hyperlog_xform_10000__1__4_5__0)
 
-        gs.add_gate(prog_test_data.poly1_gate, ('root',))
+        gs.add_gate(poly1_gate, ("root",))
 
-        dim1 = fk.Dimension('PE', 'MySpill', 'Logicle_10000_0.5_4.5_0', range_min=0.31, range_max=0.69)
-        dim2 = fk.Dimension('PerCP', 'MySpill', 'Logicle_10000_0.5_4.5_0', range_min=0.27, range_max=0.73)
+        dim1 = fk.Dimension(
+            "PE", "MySpill", "Logicle_10000_0.5_4.5_0", range_min=0.31, range_max=0.69
+        )
+        dim2 = fk.Dimension(
+            "PerCP",
+            "MySpill",
+            "Logicle_10000_0.5_4.5_0",
+            range_min=0.27,
+            range_max=0.73,
+        )
         dims1 = [dim1, dim2]
 
-        rect_gate1 = fk.gates.RectangleGate('ScaleRect1', dims1)
-        gs.add_gate(rect_gate1, ('root',))
+        rect_gate1 = fk.gates.RectangleGate("ScaleRect1", dims1)
+        gs.add_gate(rect_gate1, ("root",))
 
-        dim3 = fk.Dimension('FITC', 'MySpill', 'Hyperlog_10000_1_4.5_0', range_min=0.12, range_max=0.43)
+        dim3 = fk.Dimension(
+            "FITC", "MySpill", "Hyperlog_10000_1_4.5_0", range_min=0.12, range_max=0.43
+        )
         dims2 = [dim3]
 
-        rect_gate2 = fk.gates.RectangleGate('ScalePar1', dims2)
-        gs.add_gate(rect_gate2, ('root', 'ScaleRect1'))
+        rect_gate2 = fk.gates.RectangleGate("ScalePar1", dims2)
+        gs.add_gate(rect_gate2, ("root", "ScaleRect1"))
 
         gs_string = "GatingStrategy(3 gates, 2 transforms, 1 compensations)"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,223 @@
+import numpy as np
+import warnings
+import flowkit as fk
+
+# Paths
+data1_fcs_path = "data/gate_ref/data1.fcs"
+fcs_path = "data/gate_ref/data1.fcs"
+gml_path = "data/gate_ref/gml/gml_all_gates.xml"
+fcs_file_path = "data/test_comp_example.fcs"
+comp_file_path = "data/comp_complete_example.csv"
+fcs_2d_file_path = "data/test_data_2d_01.fcs"
+fcs_index_sorted_path = "data/index_sorted/index_sorted_example.fcs"
+sample_id_with_spill = "101_DEN084Y5_15_E01_008_clean.fcs"
+csv_8c_comp_file_path = "data/8_color_data_set/den_comp.csv"
+csv_8c_comp_null_channel_file_path = "data/8_color_data_set/den_comp_null_channel.csv"
+
+
+fcs_file_paths = ["data/100715.fcs", "data/109567.fcs", "data/113548.fcs"]
+
+# Samples
+
+data1_sample = fk.Sample(data1_fcs_path)
+data1_sample_with_orig = fk.Sample(data1_fcs_path, cache_original_events=True)
+null_chan_sample = fk.Sample(data1_fcs_path, null_channel_list=['FL1-H'])
+test_sample = fk.Sample(fcs_path, subsample=2000)
+test_samples_base_set = fk.load_samples(fcs_file_paths)
+test_samples_8c_full_set = fk.load_samples("data/8_color_data_set/fcs_files")
+test_samples_8c_full_set_dict = {s.id: s for s in test_samples_8c_full_set}
+sample_with_spill = test_samples_8c_full_set_dict[sample_id_with_spill]
+
+test_gating_strategy = fk.parse_gating_xml(gml_path)
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    test_comp_sample = fk.Sample(
+        fcs_path_or_data=fcs_file_path,
+        compensation=comp_file_path,
+        ignore_offset_error=True,  # sample has off by 1 data offset
+    )
+
+    warnings.simplefilter("ignore")
+    test_comp_sample_uncomp = fk.Sample(
+        fcs_path_or_data=fcs_file_path,
+        ignore_offset_error=True,  # sample has off by 1 data offset
+    )
+
+# np objects
+test_data_range1 = np.linspace(0.0, 10.0, 101)
+
+
+# Coordinates, Dimensions, Gates, and Quadrants
+
+ell1_coords = [12.99701, 16.22941]
+ell1_cov_mat = [[62.5, 37.5], [37.5, 62.5]]
+ell1_dist_square = 1
+
+poly1_vertices = [[5, 5], [500, 5], [500, 500]]
+poly1_dim1 = fk.Dimension("FL2-H", compensation_ref="FCS")
+poly1_dim2 = fk.Dimension("FL3-H", compensation_ref="FCS")
+poly1_dims1 = [poly1_dim1, poly1_dim2]
+
+
+poly1_gate = fk.gates.PolygonGate("Polygon1", poly1_dims1, poly1_vertices)
+
+quad1_div1 = fk.QuadrantDivider("FL2", "FL2-H", "FCS", [12.14748])
+quad1_div2 = fk.QuadrantDivider("FL4", "FL4-H", "FCS", [14.22417])
+quad1_divs = [quad1_div1, quad1_div2]
+
+quad_1 = fk.gates.Quadrant(
+    quadrant_id="FL2P-FL4P",
+    divider_refs=["FL2", "FL4"],
+    divider_ranges=[(12.14748, None), (14.22417, None)],
+)
+quad_2 = fk.gates.Quadrant(
+    quadrant_id="FL2N-FL4P",
+    divider_refs=["FL2", "FL4"],
+    divider_ranges=[(None, 12.14748), (14.22417, None)],
+)
+quad_3 = fk.gates.Quadrant(
+    quadrant_id="FL2N-FL4N",
+    divider_refs=["FL2", "FL4"],
+    divider_ranges=[(None, 12.14748), (None, 14.22417)],
+)
+quad_4 = fk.gates.Quadrant(
+    quadrant_id="FL2P-FL4N",
+    divider_refs=["FL2", "FL4"],
+    divider_ranges=[(12.14748, None), (None, 14.22417)],
+)
+quadrants_q1 = [quad_1, quad_2, quad_3, quad_4]
+
+quad1_gate = fk.gates.QuadrantGate("Quadrant1", quad1_divs, quadrants_q1)
+
+range1_dim1 = fk.Dimension("FSC-H", compensation_ref="uncompensated", range_min=100)
+range1_dims = [range1_dim1]
+range1_gate = fk.gates.RectangleGate("Range1", range1_dims)
+
+range2_dim1 = fk.Dimension(
+    "Time", compensation_ref="uncompensated", range_min=20, range_max=80
+)
+range2_dims = [range2_dim1]
+range2_gate = fk.gates.RectangleGate("Range2", range2_dims)
+
+ell1_dim1 = fk.Dimension("FL3-H", compensation_ref="uncompensated")
+ell1_dim2 = fk.Dimension("FL4-H", compensation_ref="uncompensated")
+ellipse1_dims = [ell1_dim1, ell1_dim2]
+
+
+ellipse1_gate = fk.gates.EllipsoidGate(
+    "Ellipse1", ellipse1_dims, ell1_coords, ell1_cov_mat, ell1_dist_square
+)
+
+
+# Transforms
+
+asinh_xform_10000_4_1 = fk.transforms.AsinhTransform(
+    param_t=10000,
+    param_m=4,
+    param_a=1
+)
+
+xform_biex1 = fk.transforms.WSPBiexTransform(width=-100.0, negative=0.0)
+xform_biex2 = fk.transforms.WSPBiexTransform(width=-100.0, negative=1.0)
+
+hyperlog_xform_10000__1__4_5__0 = fk.transforms.HyperlogTransform(
+    param_t=10000,
+    param_w=1,
+    param_m=4.5,
+    param_a=0
+)
+
+linear_xform_10000_500 = fk.transforms.LinearTransform(
+    param_t=10000,
+    param_a=500
+)
+
+
+logicle_xform_10000__0_5__4_5__0 = fk.transforms.LogicleTransform(
+    param_t=10000,
+    param_w=0.5,
+    param_m=4.5,
+    param_a=0
+)
+
+logicle_xform_10000__0_5__4__0_5 = fk.transforms.LogicleTransform(
+    param_t=10000,
+    param_w=0.5,
+    param_m=4,
+    param_a=0.5
+)
+logicle_xform_10000__1__4__0_5 = fk.transforms.LogicleTransform(
+    param_t=10000,
+    param_w=1,
+    param_m=4,
+    param_a=0.5
+)
+
+xform_logicle = fk.transforms.LogicleTransform(param_t=10000, param_w=0.5, param_m=4.5, param_a=0)
+
+
+# Spillover and Matrix
+
+fcs_spill = (
+    "13,B515-A,R780-A,R710-A,R660-A,V800-A,V655-A,V585-A,V450-A,G780-A,G710-A,G660-A,G610-A,G560-A,"
+    "1,0,0,0.00008841570561316703,0.0002494559842740046,0.0006451591561972469,0.007198401782797728,0,0,"
+    "0.00013132619816952714,0.0000665251222573374,0.0005815839652764308,0.0025201730479353047,0,1,"
+    "0.07118758880093266,0.14844804153215532,0.3389031912802132,0.00971660311243448,0,0,0.3013801753249257,"
+    "0.007477611134717788,0.0123543122066652,0,0,0,0.33140488468849205,1,0.0619647566095391,0.12097867005182314,"
+    "0.004052554840959644,0,0,0.1091165124197372,0.10031383324016652,0.005831773047424356,0,0,0,"
+    "0.08862108746390694,0.38942413967608824,1,0.029758767352535288,0.06555281586224636,0,0,0.03129393154653089,"
+    "0.039305936245674286,0.09137451237674046,0.00039591122341817164,0.000056659766405160846,0,"
+    "0.13661791418865094,0.010757316236957385,0,1,0.00015647113960278087,0,0,0.48323487842103036,"
+    "0.01485813345103798,0,0,0,0,0.00012365104122837034,0.019462610460087203,0.2182062762553545,"
+    "0.004953221988365214,1,0.003582785726251024,0,0.0013106968243292993,0.029645575685206288,0.4089015923558522,"
+    "0.006505826616588717,0.00011917703878954761,0,0,0,0,0.001055595075733903,0.002287122431059274,1,0,"
+    "0.0003885172922042414,0.0001942589956485108,0,0.06255131165904257,0.13248446095817049,0,0,0,0,0,"
+    "0.008117870042687002,0.17006643956891296,1,0,0,0,0,0,0.003122390646560834,0.008525685683831916,"
+    "0.001024237027323255,0.0011626412849951272,0.12540105131097395,0.018142202256893485,0.19364562239714117,"
+    "0,1,0.06689784643460173,0.16145640353506588,0.2868231743828476,1.2380368696528024,0.002015498041918758,"
+    "0.06964529385206036,0.19471548842271394,0.0010077719457714136,0.15161117217667686,0.0012703511702660231,"
+    "0.007133491446011225,0,1.1500323358669722,1,0.016076827046672983,0.014674146885307975,0.055351746085494,"
+    "0.001685226072130514,0.05433993817875603,0.27785224557295884,0.34300826602551504,0.06175281041168121,"
+    "0.07752283973796613,0.0042628794531131406,0,0.49748791920091034,0.7439226300384197,1,0.010329232815907474,"
+    "0.03763461149817695,0,0.008713148000954844,0.04821275078920058,0.07319044343609345,0.1505631929508567,"
+    "0.3862934410767249,0.10189631814602482,0,0.3702770755789083,0.6134900271606913,1.2180240147472128,1,"
+    "0.06521131251063482,0.0016842378874079343,0,0,0.00009533732312150527,0.0034630076700367675,"
+    "0.01571183587491517,0.17412189188164517,0,0.023802192010810994,0.049474451704249904,0.13251071256825273,"
+    "0.23921555785727822,1"
+)
+
+fcs_spill_header = [
+    "B515-A",
+    "R780-A",
+    "R710-A",
+    "R660-A",
+    "V800-A",
+    "V655-A",
+    "V585-A",
+    "V450-A",
+    "G780-A",
+    "G710-A",
+    "G660-A",
+    "G610-A",
+    "G560-A",
+]
+
+spill01_fluoros = ["FITC", "PE", "PerCP"]
+spill01_detectors = ["FL1-H", "FL2-H", "FL3-H"]
+spill01_data = np.array([[1, 0.02, 0.06], [0.11, 1, 0.07], [0.09, 0.01, 1]])
+comp_matrix_01 = fk.Matrix(spill01_data, spill01_detectors, spill01_fluoros)
+
+# pnn, pns lists
+
+detectors_8c = [
+    "TNFa FITC FLR-A",
+    "CD8 PerCP-Cy55 FLR-A",
+    "IL2 BV421 FLR-A",
+    "Aqua Amine FLR-A",
+    "IFNg APC FLR-A",
+    "CD3 APC-H7 FLR-A",
+    "CD107a PE FLR-A",
+    "CD4 PE-Cy7 FLR-A",
+]
+fluorochromes_8c = ["TNFa", "CD8", "IL2", "Aqua Amine", "IFNg", "CD3", "CD107a", "CD4"]

--- a/tests/transform_tests.py
+++ b/tests/transform_tests.py
@@ -7,14 +7,10 @@ import warnings
 
 from flowkit import Sample, transforms, generate_transforms
 
-data1_fcs_path = 'data/gate_ref/data1.fcs'
-data1_sample = Sample(data1_fcs_path)
+from tests.test_config import data1_sample, null_chan_sample, test_data_range1
+
+
 data1_raw_events = data1_sample.get_events(source='raw')
-
-# Sample with null channel
-null_chan_sample = Sample(data1_fcs_path, null_channel_list=['FL1-H'])
-
-test_data_range1 = np.linspace(0.0, 10.0, 101)
 
 
 class TransformsTestCase(unittest.TestCase):

--- a/tests/workspace_tests.py
+++ b/tests/workspace_tests.py
@@ -12,8 +12,9 @@ from flowkit import Workspace, Sample, load_samples, Matrix, gates, transforms, 
 from flowkit._models.transforms._base_transform import Transform
 from flowkit.exceptions import GateReferenceError
 
+from tests.test_config import test_samples_8c_full_set
 
-test_samples_8c_full_set = load_samples("data/8_color_data_set/fcs_files")
+
 wsp_8_color = Workspace(
     "data/8_color_data_set/8_color_ICS.wsp",
     fcs_samples=test_samples_8c_full_set


### PR DESCRIPTION
Factored out constants used in tests into own file: `test_config.py` for easier maintenance, some DRY, and testing of different files. Changed imports in tests from relative to absolute; vscode test discovery and other tools doesn't seem to work with relative imports. I verified that tests would run successfully using python run_tests.py, python -m unittest and running tests from vscode with imports specified this way. 