### PR TITLE
Fixed empty timestep value issue in sample.py

### DIFF
--- a/src/flowkit/_models/sample.py
+++ b/src/flowkit/_models/sample.py
@@ -320,8 +320,11 @@ class Sample(object):
             channel_gain[self.time_index] = 1.0
 
         if 'timestep' in self.metadata and self.time_index is not None:
-            time_step = float(self.metadata['timestep'])
-            raw_events[:, self.time_index] = raw_events[:, self.time_index] * time_step
+            try:
+                time_step = float(self.metadata['timestep'])
+                raw_events[:, self.time_index] = raw_events[:, self.time_index] * time_step
+            except:
+                pass
 
         for i, (decades, log0) in enumerate(channel_lin_log):
             if decades > 0:


### PR DESCRIPTION
Added try-except for timestep reading, because in some cases timestep key was in dictionary, but the value was equal to - " " e.g. empty string